### PR TITLE
fixed static 'localhost' DB hosts as env(DB_HOST...

### DIFF
--- a/app/Http/Controllers/DbadminController.php
+++ b/app/Http/Controllers/DbadminController.php
@@ -230,7 +230,7 @@ class DbadminController extends Controller
         
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $hub->id,
             'username'  => env('DB_DATABASE') . "_" . $hub->id,
             'password'  => $hub->password,

--- a/app/Http/Controllers/HubController.php
+++ b/app/Http/Controllers/HubController.php
@@ -153,7 +153,7 @@ class HubController extends Controller
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $hub->id,
             'username'  => env('DB_DATABASE') . "_" . $hub->id,
             'password'  => $hub->password,
@@ -231,7 +231,7 @@ class HubController extends Controller
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $hub->id,
             'username'  => env('DB_DATABASE') . "_" . $hub->id,
             'password'  => $hub->password,
@@ -288,7 +288,7 @@ class HubController extends Controller
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $hub->id,
             'username'  => env('DB_DATABASE') . "_" . $hub->id,
             'password'  => $hub->password,
@@ -348,7 +348,7 @@ class HubController extends Controller
 
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $hub->id,
             'username'  => env('DB_DATABASE') . "_" . $hub->id,
             'password'  => $hub->password,

--- a/app/Http/Middleware/selectdb.php
+++ b/app/Http/Middleware/selectdb.php
@@ -38,7 +38,7 @@ class selectdb
 
                 Config::set("database.connections." . env('DB_DATABASE') . "_" . $hub->id, array(
                     'driver'    => 'mysql',
-                    'host'      => 'localhost',
+                    'host'      => env('DB_HOST'),
                     'database'  => env('DB_DATABASE') . "_" . $hub->id,
                     'username'  => env('DB_DATABASE') . "_" . $hub->id,
                     'password'  => $hub->password,

--- a/app/Hub.php
+++ b/app/Hub.php
@@ -26,7 +26,7 @@ class Hub extends Model
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $this->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $this->id,
             'username'  => env('DB_DATABASE') . "_" . $this->id,
             'password'  => $this->password,
@@ -56,7 +56,7 @@ class Hub extends Model
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $this->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $this->id,
             'username'  => env('DB_DATABASE') . "_" . $this->id,
             'password'  => $this->password,
@@ -83,7 +83,7 @@ class Hub extends Model
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $this->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $this->id,
             'username'  => env('DB_DATABASE') . "_" . $this->id,
             'password'  => $this->password,
@@ -105,7 +105,7 @@ class Hub extends Model
         //set db
         Config::set("database.connections." . env('DB_DATABASE') . "_" . $this->id, array(
             'driver'    => 'mysql',
-            'host'      => 'localhost',
+            'host'      => env('DB_HOST'),
             'database'  => env('DB_DATABASE') . "_" . $this->id,
             'username'  => env('DB_DATABASE') . "_" . $this->id,
             'password'  => $this->password,


### PR DESCRIPTION
Hallo,

mir sind (bei meinen Versuchen, das ganze auf Docker zum laufen zu bekommen) ein paar "fest verdrahtete" Referenzen auf "localhost" statt "env('DB_HOST')" aufgefallen. In diesem PR sind diese entsprechend korrigiert.

Viele Grüße,
Mathias
