### PR TITLE
Display 'NULL' instead of nothing for fields with `NULL` values

### DIFF
--- a/app/Http/Controllers/SqlController.php
+++ b/app/Http/Controllers/SqlController.php
@@ -63,7 +63,11 @@ class SqlController extends Controller
                             $row = (array) $row;
                             $t = $t.'<tr>';
                             foreach ($cols as &$col) {
-                                $wert = htmlspecialchars($row[$col]);
+                                if ($row[$col] === null) {
+                                    $wert = '<code>NULL</code>';
+                                } else {
+                                    $wert = htmlspecialchars($row[$col]);
+                                }
                                 //Ausgabe ggf. anpassen - Links
                                 if (filter_var($wert, FILTER_VALIDATE_URL)) {
                                     $wert = "<a href='$wert'>$wert</a>";


### PR DESCRIPTION
Closes #64
| before | after |
| :--------: | :------: |
| ![grafik](https://user-images.githubusercontent.com/17365767/224362747-61dbc6ca-ec43-4555-b1bd-57cf096d0134.png) | ![grafik](https://user-images.githubusercontent.com/17365767/224362365-4f8b3ff8-974b-40e0-8b38-ddb6d62e4357.png) |
