### PR TITLE
Change editor text color to white

### DIFF
--- a/resources/sass/app.scss
+++ b/resources/sass/app.scss
@@ -118,6 +118,7 @@ a {
         background-color: #212529;
         border-color: #495057;
         caret-color: #f8f9fa;
+        color: white;
     }
     
     #editor:focus-within .preview,


### PR DESCRIPTION
# Issue:
When dark mode was enabled, SQL queries were unreadable due to insufficient color contrast.
# Fix:
The text color for SQL queries was changed to white, restoring readability in dark mode.