### PR TITLE
Add Pest test suite (384 tests) and CI for the multi-tenant app

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,67 @@
+name: Tests
+
+on:
+  push:
+    branches:
+      - main
+      - "claude/**"
+  pull_request:
+
+jobs:
+  pest:
+    name: Pest (PHP ${{ matrix.php }})
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.3']
+
+    env:
+      DB_CONNECTION: mysql
+      DB_HOST: 127.0.0.1
+      DB_PORT: 3306
+      DB_DATABASE: testing
+      DB_USERNAME: root
+      DB_PASSWORD: root
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      # InstaHub is a multi-tenant app that provisions one database per hub via
+      # `CREATE DATABASE` + `GRANT ... IDENTIFIED BY` and connects tenants over
+      # `@'localhost'`. That syntax needs MariaDB (removed in MySQL 8) and the DB
+      # must run ON the runner (not a service container) so that connections to
+      # 127.0.0.1 resolve to `localhost` and the tenant grants match.
+      - name: Install and start MariaDB
+        run: |
+          sudo systemctl stop mysql || true
+          sudo DEBIAN_FRONTEND=noninteractive apt-get purge -y mysql-server mysql-client mysql-common 'mysql-server-*' || true
+          sudo DEBIAN_FRONTEND=noninteractive apt-get update
+          sudo DEBIAN_FRONTEND=noninteractive apt-get install -y mariadb-server
+          sudo systemctl start mariadb || sudo service mariadb start || (sudo mysqld_safe --user=mysql & sleep 8)
+          # Give root a password usable over TCP (127.0.0.1 -> localhost).
+          sudo mysql -e "ALTER USER 'root'@'localhost' IDENTIFIED VIA mysql_native_password USING PASSWORD('root'); FLUSH PRIVILEGES;"
+          mysql -uroot -proot -h127.0.0.1 -e "CREATE DATABASE IF NOT EXISTS testing CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;"
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, dom, fileinfo, pdo, pdo_mysql, mysqli, bcmath, gd, intl, zip, exif, curl, openssl
+          coverage: none
+          tools: composer:v2
+
+      - name: Cache Composer packages
+        uses: actions/cache@v4
+        with:
+          path: vendor
+          key: composer-${{ runner.os }}-php${{ matrix.php }}-${{ hashFiles('composer.lock') }}
+          restore-keys: composer-${{ runner.os }}-php${{ matrix.php }}-
+
+      - name: Install Composer dependencies
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Run Pest
+        run: php vendor/bin/pest --colors=always

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -100,7 +100,7 @@ class RegisterController extends Controller implements HasMiddleware
             'password' => 'required|min:6|confirmed',
             'bio' => 'nullable|max:500',
             'gender' => 'nullable',
-            'birthday_birthDay' => 'nullable|date_format:Y-m-d',
+            'birthday' => 'nullable|date_format:Y-m-d',
             'city' => 'nullable|string',
             'country' => 'nullable|string',
             'centimeters' => 'nullable|numeric',

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\Comment as CommentResource;
 use App\Models\Comment;
+use App\Models\Photo;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Support\Facades\Auth;
@@ -38,7 +39,15 @@ class CommentController extends Controller implements HasMiddleware
     {
         $entry = Comment::find($id);
 
-        // $this->authorize('view', $entry);
+        abort_if($entry === null, 404);
+
+        // A comment may be removed by its author or by the owner of the photo
+        // it belongs to.
+        $photoOwnerId = Photo::whereKey($entry->photo_id)->value('user_id');
+        abort_unless(
+            $entry->user_id === Auth::id() || $photoOwnerId === Auth::id(),
+            403
+        );
 
         $entry->delete();
 

--- a/app/Http/Controllers/CommentController.php
+++ b/app/Http/Controllers/CommentController.php
@@ -4,10 +4,10 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\Comment as CommentResource;
 use App\Models\Comment;
-use App\Models\Photo;
 use Illuminate\Http\Request;
 use Illuminate\Routing\Controllers\HasMiddleware;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 
 class CommentController extends Controller implements HasMiddleware
 {
@@ -37,17 +37,9 @@ class CommentController extends Controller implements HasMiddleware
      */
     public function destroy($id)
     {
-        $entry = Comment::find($id);
+        $entry = Comment::findOrFail($id);
 
-        abort_if($entry === null, 404);
-
-        // A comment may be removed by its author or by the owner of the photo
-        // it belongs to.
-        $photoOwnerId = Photo::whereKey($entry->photo_id)->value('user_id');
-        abort_unless(
-            $entry->user_id === Auth::id() || $photoOwnerId === Auth::id(),
-            403
-        );
+        Gate::authorize('delete', $entry);
 
         $entry->delete();
 

--- a/app/Http/Controllers/HubController.php
+++ b/app/Http/Controllers/HubController.php
@@ -136,7 +136,7 @@ class HubController extends Controller implements HasMiddleware
         // check if teacher
         $teacherId = null;
         if (Auth::check()) {
-            if (Auth::user()->role = 'teacher' || Auth::user()->role = 'mod') {
+            if (Auth::user()->role == 'teacher' || Auth::user()->role == 'mod') {
                 $teacherId = Auth::user()->id;
             }
         }
@@ -194,8 +194,7 @@ class HubController extends Controller implements HasMiddleware
                 }
             }
 
-            $admin = User::where('username', 'admin')->first();
-            $admin->update([
+            $adminAttributes = [
                 'name' => $request->name,
                 'email' => $request->email,
                 'password' => bcrypt($request->password),
@@ -207,7 +206,18 @@ class HubController extends Controller implements HasMiddleware
                 'centimeters' => $request->centimeters,
                 'avatar' => $url,
                 'is_active' => ($teacherId && Auth::user()->id == $teacherId), // trust yourself
-            ]);
+            ];
+
+            $admin = User::where('username', 'admin')->first();
+            if ($admin) {
+                $admin->update($adminAttributes);
+            } else {
+                // The `all_empty` creating mode only migrates empty tables, so no
+                // `admin` user is seeded. Create one so the hub stays manageable.
+                $admin = User::create(array_merge(['username' => 'admin'], $adminAttributes));
+                $admin->role = 'dba'; // role is not mass assignable for security reasons
+                $admin->save();
+            }
         });
 
         if ($teacherId && Auth::user()->id == $teacherId) {

--- a/app/Http/Resources/Hub.php
+++ b/app/Http/Resources/Hub.php
@@ -13,15 +13,15 @@ class Hub extends JsonResource
      */
     public function toArray($request): array
     {
-        $hasWorkingUser = $this->hasWorkingUser();
+        $hasWorkingUser = $this->has_working_user;
 
         return [
             'id' => $this->id,
             'name' => $this->name,
             'hasWorkingUser' => $hasWorkingUser,
-            'activated' => ($hasWorkingUser) ? $this->activated() : false,
+            'activated' => ($hasWorkingUser) ? $this->activated : false,
             'admin' => ($hasWorkingUser) ? $this->admin : '',
-            'readonly' => $this->readonly(),
+            'readonly' => $this->readonly,
             'created_at' => $this->created_at,
         ];
     }

--- a/app/Livewire/Photo/Show.php
+++ b/app/Livewire/Photo/Show.php
@@ -5,6 +5,7 @@ namespace App\Livewire\Photo;
 use App\Facades\RequestHub;
 use App\Models\Photo;
 use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\Gate;
 use Livewire\Component;
 
 class Show extends Component
@@ -95,11 +96,13 @@ class Show extends Component
 
     public function deleteComment($commentId)
     {
-        if ($this->readonly || ! $this->admin || ! RequestHub::hasTable('comments')) {
+        if ($this->readonly || ! RequestHub::hasTable('comments')) {
             return;
         }
 
-        $this->photo->comments()->find($commentId)->delete();
+        $comment = $this->photo->comments()->findOrFail($commentId);
+        Gate::authorize('delete', $comment);
+        $comment->delete();
         $this->photo->refresh();
         $this->loadPhotoRelations();
     }

--- a/app/Models/Ad.php
+++ b/app/Models/Ad.php
@@ -4,10 +4,13 @@ namespace App\Models;
 
 use Auth;
 use DB;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 
 class Ad extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['name', 'type', 'priority', 'url', 'img', 'query'];
 
     public static function getAd($photo_id = null)

--- a/app/Models/Analytic.php
+++ b/app/Models/Analytic.php
@@ -3,11 +3,14 @@
 namespace App\Models;
 
 use Browser;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Analytic extends Model
 {
+    use HasFactory;
+
     // protected $fillable = ['ip', 'device', 'brand_family', 'brand_model', 'browser_family', 'browser_version', 'platform_family', 'platform_version', 'user_id', 'photo_id'];
     protected $fillable = ['user_id', 'photo_id'];
 

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -19,6 +19,11 @@ class Comment extends Model
         return $this->belongsTo(\App\Models\User::class);
     }
 
+    public function photo(): BelongsTo
+    {
+        return $this->belongsTo(\App\Models\Photo::class);
+    }
+
     public function getHtmlAttribute()
     {
         $html = htmlspecialchars($this->body); // secure user input

--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Comment extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['user_id', 'photo_id', 'body'];
 
     protected $with = ['user'];

--- a/app/Models/Hub.php
+++ b/app/Models/Hub.php
@@ -3,6 +3,7 @@
 namespace App\Models;
 
 use App\Facades\RequestHub;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Support\Facades\Artisan;
@@ -11,6 +12,8 @@ use Illuminate\Support\Facades\Schema;
 
 class Hub extends Model
 {
+    use HasFactory;
+
     protected $table = 'hubs';
 
     protected $readonlyCache = null;

--- a/app/Models/Like.php
+++ b/app/Models/Like.php
@@ -2,11 +2,14 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Like extends Model
 {
+    use HasFactory;
+
     protected $fillable = ['photo_id', 'user_id'];
 
     public function user(): BelongsTo

--- a/app/Models/Photo.php
+++ b/app/Models/Photo.php
@@ -4,6 +4,7 @@ namespace App\Models;
 
 use App\Collections\PhotoCollection;
 use App\Facades\RequestHub;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 use Illuminate\Database\Eloquent\Relations\HasMany;
@@ -11,6 +12,8 @@ use Illuminate\Support\Facades\Storage;
 
 class Photo extends Model
 {
+    use HasFactory;
+
     protected $table = 'photos';
 
     protected $fillable = ['user_id', 'description', 'url'];

--- a/app/Models/Tag.php
+++ b/app/Models/Tag.php
@@ -2,11 +2,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
 
 class Tag extends Model
 {
+    use HasFactory;
+
+    protected $fillable = ['photo_id', 'name'];
+
     public function photo(): BelongsTo
     {
         return $this->belongsTo(\App\Models\Photo::class);

--- a/app/Policies/CommentPolicy.php
+++ b/app/Policies/CommentPolicy.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Policies;
+
+use App\Models\Comment;
+use App\Models\User;
+
+class CommentPolicy
+{
+    /**
+     * Determine whether the user can delete the comment.
+     *
+     * Allowed if the user is the comment author or the owner of the photo
+     * the comment belongs to.
+     */
+    public function delete(User $user, Comment $comment): bool
+    {
+        return $user->id === $comment->user_id
+            || $user->id === $comment->photo->user_id;
+    }
+}

--- a/composer.json
+++ b/composer.json
@@ -29,7 +29,10 @@
         "laravel/sail": "^1.41",
         "mockery/mockery": "^1.6",
         "nunomaduro/collision": "^8.6",
-        "phpunit/phpunit": "^11.5.3"
+        "pestphp/pest": "^4.7",
+        "pestphp/pest-plugin-laravel": "^4.1",
+        "pestphp/pest-plugin-livewire": "^4.1",
+        "phpunit/phpunit": "^12.5"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -94,6 +94,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "platform": {
+            "php": "8.3.31"
         }
     },
     "minimum-stability": "stable",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "537c86c6a87e323f3cdf4ada1e3da5ad",
+    "content-hash": "63dc1c1d377360fffa2cfb20bfa7d905",
     "packages": [
         {
             "name": "brick/math",
@@ -137,16 +137,16 @@
         },
         {
             "name": "composer/ca-bundle",
-            "version": "1.5.10",
+            "version": "1.5.12",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/ca-bundle.git",
-                "reference": "961a5e4056dd2e4a2eedcac7576075947c28bf63"
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/961a5e4056dd2e4a2eedcac7576075947c28bf63",
-                "reference": "961a5e4056dd2e4a2eedcac7576075947c28bf63",
+                "url": "https://api.github.com/repos/composer/ca-bundle/zipball/00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
+                "reference": "00a2f4201641d5c53f7fc0195e6c8d9fcc321a78",
                 "shasum": ""
             },
             "require": {
@@ -193,7 +193,7 @@
             "support": {
                 "irc": "irc://irc.freenode.org/composer",
                 "issues": "https://github.com/composer/ca-bundle/issues",
-                "source": "https://github.com/composer/ca-bundle/tree/1.5.10"
+                "source": "https://github.com/composer/ca-bundle/tree/1.5.12"
             },
             "funding": [
                 {
@@ -205,7 +205,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-08T15:06:51+00:00"
+            "time": "2026-05-19T11:26:22+00:00"
         },
         {
             "name": "dflydev/dot-access-data",
@@ -1272,16 +1272,16 @@
         },
         {
             "name": "intervention/image",
-            "version": "3.11.7",
+            "version": "3.11.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image.git",
-                "reference": "2159bcccff18f09d2a392679b81a82c5a003f9bb"
+                "reference": "cf04c8dd245697f701057c13d4bfe140d584e738"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image/zipball/2159bcccff18f09d2a392679b81a82c5a003f9bb",
-                "reference": "2159bcccff18f09d2a392679b81a82c5a003f9bb",
+                "url": "https://api.github.com/repos/Intervention/image/zipball/cf04c8dd245697f701057c13d4bfe140d584e738",
+                "reference": "cf04c8dd245697f701057c13d4bfe140d584e738",
                 "shasum": ""
             },
             "require": {
@@ -1294,7 +1294,7 @@
                 "phpstan/phpstan": "^2.1",
                 "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
                 "slevomat/coding-standard": "~8.0",
-                "squizlabs/php_codesniffer": "^3.8"
+                "squizlabs/php_codesniffer": "^4"
             },
             "suggest": {
                 "ext-exif": "Recommended to be able to read EXIF data properly."
@@ -1328,7 +1328,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image/issues",
-                "source": "https://github.com/Intervention/image/tree/3.11.7"
+                "source": "https://github.com/Intervention/image/tree/3.11.8"
             },
             "funding": [
                 {
@@ -1344,20 +1344,20 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-02-19T13:11:17+00:00"
+            "time": "2026-05-01T08:20:10+00:00"
         },
         {
             "name": "intervention/image-laravel",
-            "version": "1.5.8",
+            "version": "1.5.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Intervention/image-laravel.git",
-                "reference": "78b609a3fd10da12dae03cc6a5e0a32a3e603714"
+                "reference": "a760b041e5133fd81509414f4955c93ffefb4a7b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Intervention/image-laravel/zipball/78b609a3fd10da12dae03cc6a5e0a32a3e603714",
-                "reference": "78b609a3fd10da12dae03cc6a5e0a32a3e603714",
+                "url": "https://api.github.com/repos/Intervention/image-laravel/zipball/a760b041e5133fd81509414f4955c93ffefb4a7b",
+                "reference": "a760b041e5133fd81509414f4955c93ffefb4a7b",
                 "shasum": ""
             },
             "require": {
@@ -1412,7 +1412,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Intervention/image-laravel/issues",
-                "source": "https://github.com/Intervention/image-laravel/tree/1.5.8"
+                "source": "https://github.com/Intervention/image-laravel/tree/1.5.9"
             },
             "funding": [
                 {
@@ -1428,27 +1428,27 @@
                     "type": "ko_fi"
                 }
             ],
-            "time": "2026-03-20T16:16:10+00:00"
+            "time": "2026-03-24T15:10:30+00:00"
         },
         {
             "name": "jaybizzle/crawler-detect",
-            "version": "v1.3.7",
+            "version": "v1.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/JayBizzle/Crawler-Detect.git",
-                "reference": "7f7a45b5d5df9c95ba6b2008544e6cf8e66de6f5"
+                "reference": "20d7bd4a6ee68444693fe75bc5c6f12f65ad512d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/7f7a45b5d5df9c95ba6b2008544e6cf8e66de6f5",
-                "reference": "7f7a45b5d5df9c95ba6b2008544e6cf8e66de6f5",
+                "url": "https://api.github.com/repos/JayBizzle/Crawler-Detect/zipball/20d7bd4a6ee68444693fe75bc5c6f12f65ad512d",
+                "reference": "20d7bd4a6ee68444693fe75bc5c6f12f65ad512d",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.1.0"
+                "php": ">=7.2.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^4.8|^5.5|^6.5|^7.5|^8.5|^9.4"
+                "phpunit/phpunit": "^8.5.52|^9.4"
             },
             "type": "library",
             "autoload": {
@@ -1478,22 +1478,22 @@
             ],
             "support": {
                 "issues": "https://github.com/JayBizzle/Crawler-Detect/issues",
-                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.3.7"
+                "source": "https://github.com/JayBizzle/Crawler-Detect/tree/v1.4.0"
             },
-            "time": "2026-02-02T19:15:54+00:00"
+            "time": "2026-06-11T18:29:41+00:00"
         },
         {
             "name": "laracasts/flash",
-            "version": "3.2.5",
+            "version": "3.2.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laracasts/flash.git",
-                "reference": "29a2d76da837593dc5fb21a6bbe5f2025188a108"
+                "reference": "4fc18fed3152d8910ed64589b0f5d049fd6a0806"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laracasts/flash/zipball/29a2d76da837593dc5fb21a6bbe5f2025188a108",
-                "reference": "29a2d76da837593dc5fb21a6bbe5f2025188a108",
+                "url": "https://api.github.com/repos/laracasts/flash/zipball/4fc18fed3152d8910ed64589b0f5d049fd6a0806",
+                "reference": "4fc18fed3152d8910ed64589b0f5d049fd6a0806",
                 "shasum": ""
             },
             "require": {
@@ -1535,9 +1535,9 @@
             ],
             "description": "Easy flash notifications",
             "support": {
-                "source": "https://github.com/laracasts/flash/tree/3.2.5"
+                "source": "https://github.com/laracasts/flash/tree/3.2.6"
             },
-            "time": "2026-02-24T22:05:36+00:00"
+            "time": "2026-03-25T17:55:04+00:00"
         },
         {
             "name": "laravel/framework",
@@ -2703,16 +2703,16 @@
         },
         {
             "name": "matomo/device-detector",
-            "version": "6.5.0",
+            "version": "6.5.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/matomo-org/device-detector.git",
-                "reference": "e0fff2309dad83eb3cfb2564e524be715cfcf3cf"
+                "reference": "f30457500c6be4c80c8830466f8a746724779fd0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/e0fff2309dad83eb3cfb2564e524be715cfcf3cf",
-                "reference": "e0fff2309dad83eb3cfb2564e524be715cfcf3cf",
+                "url": "https://api.github.com/repos/matomo-org/device-detector/zipball/f30457500c6be4c80c8830466f8a746724779fd0",
+                "reference": "f30457500c6be4c80c8830466f8a746724779fd0",
                 "shasum": ""
             },
             "require": {
@@ -2726,11 +2726,11 @@
                 "matthiasmullie/scrapbook": "^1.4.7",
                 "mayflower/mo4-coding-standard": "^v9.0.0",
                 "phpstan/phpstan": "^1.10.44",
-                "phpunit/phpunit": "^8.5.2 || ^9 || ^10 || ^11 || ^12",
+                "phpunit/phpunit": "^8.5.2 || ^9 || ^10 || ^11 || ^12 || ^13",
                 "psr/cache": "^1.0.1 || ^2.0 || ^3.0",
                 "psr/simple-cache": "^1.0.1 || ^2.0 || ^3.0",
                 "slevomat/coding-standard": "<8.16.0",
-                "symfony/yaml": "^5.1.7"
+                "symfony/yaml": "^5.4 || ^6.4 || ^7.4 || ^8.0"
             },
             "suggest": {
                 "ext-yaml": "Necessary for using the Pecl YAML parser"
@@ -2766,34 +2766,34 @@
                 "forum": "https://forum.matomo.org/",
                 "issues": "https://github.com/matomo-org/device-detector/issues",
                 "source": "https://github.com/matomo-org/matomo",
-                "wiki": "https://dev.matomo.org/"
+                "wiki": "https://developer.matomo.org/"
             },
-            "time": "2026-01-21T07:53:39+00:00"
+            "time": "2026-05-27T09:53:26+00:00"
         },
         {
             "name": "mobiledetect/mobiledetectlib",
-            "version": "4.8.10",
+            "version": "4.11.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/serbanghita/Mobile-Detect.git",
-                "reference": "96b1e1fa9a968de7660a031106ab529f659d0192"
+                "reference": "ab39168b7556f44c11c80be1222b44b239f5c2e4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/96b1e1fa9a968de7660a031106ab529f659d0192",
-                "reference": "96b1e1fa9a968de7660a031106ab529f659d0192",
+                "url": "https://api.github.com/repos/serbanghita/Mobile-Detect/zipball/ab39168b7556f44c11c80be1222b44b239f5c2e4",
+                "reference": "ab39168b7556f44c11c80be1222b44b239f5c2e4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.0",
-                "psr/simple-cache": "^3"
+                "php": ">=8.2",
+                "psr/simple-cache": "^1.0 || ^2.0 || ^3.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^v3.75.0",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^2.1.11",
-                "phpunit/phpunit": "^9.6.22",
-                "squizlabs/php_codesniffer": "^3.12.1"
+                "friendsofphp/php-cs-fixer": "3.95.1",
+                "phpbench/phpbench": "1.6.1",
+                "phpstan/phpstan": "2.1.47",
+                "phpunit/phpunit": "9.6.34",
+                "squizlabs/php_codesniffer": "3.13.5"
             },
             "type": "library",
             "autoload": {
@@ -2824,7 +2824,7 @@
             ],
             "support": {
                 "issues": "https://github.com/serbanghita/Mobile-Detect/issues",
-                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.8.10"
+                "source": "https://github.com/serbanghita/Mobile-Detect/tree/4.11.0"
             },
             "funding": [
                 {
@@ -2832,7 +2832,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-01-09T16:21:59+00:00"
+            "time": "2026-05-24T12:32:40+00:00"
         },
         {
             "name": "monolog/monolog",
@@ -3492,16 +3492,16 @@
         },
         {
             "name": "orangehill/iseed",
-            "version": "v3.8.0",
+            "version": "v3.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/orangehill/iseed.git",
-                "reference": "11ee04a43330b5241be9f7b97dcd9d44bc5745f2"
+                "reference": "15ce002707c8cc3806544c0a24661e3b619cb9d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/orangehill/iseed/zipball/11ee04a43330b5241be9f7b97dcd9d44bc5745f2",
-                "reference": "11ee04a43330b5241be9f7b97dcd9d44bc5745f2",
+                "url": "https://api.github.com/repos/orangehill/iseed/zipball/15ce002707c8cc3806544c0a24661e3b619cb9d9",
+                "reference": "15ce002707c8cc3806544c0a24661e3b619cb9d9",
                 "shasum": ""
             },
             "require": {
@@ -3549,31 +3549,31 @@
             ],
             "support": {
                 "issues": "https://github.com/orangehill/iseed/issues",
-                "source": "https://github.com/orangehill/iseed/tree/v3.8.0"
+                "source": "https://github.com/orangehill/iseed/tree/v3.8.1"
             },
-            "time": "2026-02-23T07:40:35+00:00"
+            "time": "2026-06-24T08:59:33+00:00"
         },
         {
             "name": "ossycodes/friendlycaptcha",
-            "version": "v3.0.0",
+            "version": "v3.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ossycodes/friendlycaptcha.git",
-                "reference": "b18dfab44ee5fff7d75412232eb6f834864efde6"
+                "reference": "fbc0b1741be3192e803241117d437650c6bf7c6d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ossycodes/friendlycaptcha/zipball/b18dfab44ee5fff7d75412232eb6f834864efde6",
-                "reference": "b18dfab44ee5fff7d75412232eb6f834864efde6",
+                "url": "https://api.github.com/repos/ossycodes/friendlycaptcha/zipball/fbc0b1741be3192e803241117d437650c6bf7c6d",
+                "reference": "fbc0b1741be3192e803241117d437650c6bf7c6d",
                 "shasum": ""
             },
             "require": {
                 "guzzlehttp/guzzle": "^7.0",
-                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0",
-                "php": "^7.4|^8.0|^8.1|^8.2|^8.3"
+                "illuminate/support": "^8.0|^9.0|^10.0|^11.0|^12.0|^13.0",
+                "php": "^7.4|^8.0|^8.1|^8.2|^8.3|^8.4"
             },
             "require-dev": {
-                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0",
+                "orchestra/testbench": "^6.0|^7.0|^8.0|^9.0|^10.0|^11.0",
                 "phpunit/phpunit": "^8.0 || ^9.5 || ^10.5 || ^11.0 || ^12.0"
             },
             "type": "library",
@@ -3612,9 +3612,9 @@
             ],
             "support": {
                 "issues": "https://github.com/ossycodes/friendlycaptcha/issues",
-                "source": "https://github.com/ossycodes/friendlycaptcha/tree/v3.0.0"
+                "source": "https://github.com/ossycodes/friendlycaptcha/tree/v3.1.0"
             },
-            "time": "2025-05-08T13:30:49+00:00"
+            "time": "2026-05-27T10:16:09+00:00"
         },
         {
             "name": "php-http/discovery",
@@ -4240,16 +4240,16 @@
         },
         {
             "name": "psy/psysh",
-            "version": "v0.12.21",
+            "version": "v0.12.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/bobthecow/psysh.git",
-                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97"
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
-                "reference": "4821fab5b7cd8c49a673a9fd5754dc9162bb9e97",
+                "url": "https://api.github.com/repos/bobthecow/psysh/zipball/ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
+                "reference": "ca0fdcf8a7617afa3adfdf1b5fef573dffb69ca1",
                 "shasum": ""
             },
             "require": {
@@ -4313,9 +4313,9 @@
             ],
             "support": {
                 "issues": "https://github.com/bobthecow/psysh/issues",
-                "source": "https://github.com/bobthecow/psysh/tree/v0.12.21"
+                "source": "https://github.com/bobthecow/psysh/tree/v0.12.24"
             },
-            "time": "2026-03-06T21:21:28+00:00"
+            "time": "2026-06-29T15:41:09+00:00"
         },
         {
             "name": "ralouphie/getallheaders",
@@ -4517,21 +4517,22 @@
         },
         {
             "name": "symfony/clock",
-            "version": "v8.1.0",
+            "version": "v7.4.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
-                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/674fa3b98e21531dd040e613479f5f6fa8f32111",
+                "reference": "674fa3b98e21531dd040e613479f5f6fa8f32111",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "psr/clock": "^1.0"
+                "php": ">=8.2",
+                "psr/clock": "^1.0",
+                "symfony/polyfill-php83": "^1.28"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -4570,7 +4571,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v8.1.0"
+                "source": "https://github.com/symfony/clock/tree/v7.4.8"
             },
             "funding": [
                 {
@@ -4590,7 +4591,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-03-24T13:12:05+00:00"
         },
         {
             "name": "symfony/console",
@@ -4692,20 +4693,20 @@
         },
         {
             "name": "symfony/css-selector",
-            "version": "v8.1.0",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
-                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/b75663ed96cf4756e28e3105476f220f92886cc4",
+                "reference": "b75663ed96cf4756e28e3105476f220f92886cc4",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1"
+                "php": ">=8.2"
             },
             "type": "library",
             "autoload": {
@@ -4737,7 +4738,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
+                "source": "https://github.com/symfony/css-selector/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -4757,7 +4758,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-04-18T13:18:21+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
@@ -4914,25 +4915,24 @@
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v8.1.1",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
-                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/51fe3d170227be8d1772214b82ae506e15ed78ff",
+                "reference": "51fe3d170227be8d1772214b82ae506e15ed78ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/deprecation-contracts": "^2.5|^3",
+                "php": ">=8.2",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/security-http": "<7.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -4941,14 +4941,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/error-handler": "^7.4|^8.0",
-                "symfony/expression-language": "^7.4|^8.0",
-                "symfony/framework-bundle": "^7.4|^8.0",
-                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/error-handler": "^6.4|^7.0|^8.0",
+                "symfony/expression-language": "^6.4|^7.0|^8.0",
+                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
+                "symfony/http-foundation": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^7.4|^8.0"
+                "symfony/stopwatch": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4976,7 +4976,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4996,7 +4996,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-09T12:28:30+00:00"
+            "time": "2026-06-06T11:10:32+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -6588,34 +6588,35 @@
         },
         {
             "name": "symfony/string",
-            "version": "v8.1.0",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
-                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "url": "https://api.github.com/repos/symfony/string/zipball/961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
+                "reference": "961683010db3b27ec6ebcd7308e6e1ee8fa7ffde",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-ctype": "^1.8",
-                "symfony/polyfill-intl-grapheme": "^1.33",
-                "symfony/polyfill-intl-normalizer": "^1.0",
-                "symfony/polyfill-mbstring": "^1.0"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3.0",
+                "symfony/polyfill-ctype": "~1.8",
+                "symfony/polyfill-intl-grapheme": "~1.33",
+                "symfony/polyfill-intl-normalizer": "~1.0",
+                "symfony/polyfill-mbstring": "~1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.4|^8.0",
-                "symfony/http-client": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/emoji": "^7.1|^8.0",
+                "symfony/http-client": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^7.4|^8.0"
+                "symfony/var-exporter": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6654,7 +6655,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v8.1.0"
+                "source": "https://github.com/symfony/string/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6674,31 +6675,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-29T05:06:50+00:00"
+            "time": "2026-05-23T15:23:29+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v8.1.1",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
+                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
-                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
+                "reference": "a1af4dacb24eb7ef4f1ca71b94da8ddbce572281",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.4.1",
-                "symfony/polyfill-mbstring": "^1.0",
-                "symfony/translation-contracts": "^3.6.1"
+                "php": ">=8.2",
+                "symfony/deprecation-contracts": "^2.5|^3",
+                "symfony/polyfill-mbstring": "~1.0",
+                "symfony/translation-contracts": "^2.5.3|^3.3"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
+                "symfony/config": "<6.4",
+                "symfony/console": "<6.4",
+                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/service-contracts": "<2.5"
+                "symfony/http-kernel": "<6.4",
+                "symfony/service-contracts": "<2.5",
+                "symfony/twig-bundle": "<6.4",
+                "symfony/yaml": "<6.4"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -6706,17 +6714,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^7.4|^8.0",
-                "symfony/console": "^7.4|^8.0",
-                "symfony/dependency-injection": "^7.4|^8.0",
-                "symfony/finder": "^7.4|^8.0",
+                "symfony/config": "^6.4|^7.0|^8.0",
+                "symfony/console": "^6.4|^7.0|^8.0",
+                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
+                "symfony/finder": "^6.4|^7.0|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^7.4|^8.0",
-                "symfony/intl": "^7.4|^8.0",
+                "symfony/http-kernel": "^6.4|^7.0|^8.0",
+                "symfony/intl": "^6.4|^7.0|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^7.4|^8.0",
+                "symfony/routing": "^6.4|^7.0|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^7.4|^8.0"
+                "symfony/yaml": "^6.4|^7.0|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6747,7 +6755,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v8.1.1"
+                "source": "https://github.com/symfony/translation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -6767,7 +6775,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-06-06T11:11:44+00:00"
+            "time": "2026-06-06T09:33:19+00:00"
         },
         {
             "name": "symfony/translation-contracts",
@@ -7349,16 +7357,16 @@
         },
         {
             "name": "barryvdh/laravel-debugbar",
-            "version": "v4.1.3",
+            "version": "v4.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/fruitcake/laravel-debugbar.git",
-                "reference": "b48a68c4f8ffcdfa3a10d49930da4b03588dc87b"
+                "reference": "80ef956bda9e1a5824037d6f2cd06e73092e5634"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/b48a68c4f8ffcdfa3a10d49930da4b03588dc87b",
-                "reference": "b48a68c4f8ffcdfa3a10d49930da4b03588dc87b",
+                "url": "https://api.github.com/repos/fruitcake/laravel-debugbar/zipball/80ef956bda9e1a5824037d6f2cd06e73092e5634",
+                "reference": "80ef956bda9e1a5824037d6f2cd06e73092e5634",
                 "shasum": ""
             },
             "require": {
@@ -7366,11 +7374,12 @@
                 "illuminate/session": "^11|^12|^13.0",
                 "illuminate/support": "^11|^12|^13.0",
                 "php": "^8.2",
-                "php-debugbar/php-debugbar": "^3.5",
+                "php-debugbar/php-debugbar": "^3.8.0",
                 "php-debugbar/symfony-bridge": "^1.1"
             },
             "require-dev": {
                 "larastan/larastan": "^3",
+                "laravel/ai": "^0.8",
                 "laravel/octane": "^2",
                 "laravel/pennant": "^1",
                 "laravel/pint": "^1",
@@ -7395,7 +7404,7 @@
                     ]
                 },
                 "branch-alias": {
-                    "dev-master": "4.1-dev"
+                    "dev-master": "4.2-dev"
                 }
             },
             "autoload": {
@@ -7432,7 +7441,7 @@
             ],
             "support": {
                 "issues": "https://github.com/fruitcake/laravel-debugbar/issues",
-                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.1.3"
+                "source": "https://github.com/fruitcake/laravel-debugbar/tree/v4.4.0"
             },
             "funding": [
                 {
@@ -7444,7 +7453,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-09T14:55:04+00:00"
+            "time": "2026-07-04T08:30:57+00:00"
         },
         {
             "name": "brianium/paratest",
@@ -7611,16 +7620,16 @@
         },
         {
             "name": "composer/class-map-generator",
-            "version": "1.7.1",
+            "version": "1.7.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/class-map-generator.git",
-                "reference": "8f5fa3cc214230e71f54924bd0197a3bcc705eb1"
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/8f5fa3cc214230e71f54924bd0197a3bcc705eb1",
-                "reference": "8f5fa3cc214230e71f54924bd0197a3bcc705eb1",
+                "url": "https://api.github.com/repos/composer/class-map-generator/zipball/86d8208fc3c649a3a999daf1a63c25201be2990f",
+                "reference": "86d8208fc3c649a3a999daf1a63c25201be2990f",
                 "shasum": ""
             },
             "require": {
@@ -7664,7 +7673,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/class-map-generator/issues",
-                "source": "https://github.com/composer/class-map-generator/tree/1.7.1"
+                "source": "https://github.com/composer/class-map-generator/tree/1.7.3"
             },
             "funding": [
                 {
@@ -7676,7 +7685,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-12-29T13:15:25+00:00"
+            "time": "2026-05-05T09:17:07+00:00"
         },
         {
             "name": "composer/pcre",
@@ -8080,16 +8089,16 @@
         },
         {
             "name": "dragon-code/support",
-            "version": "6.17.0",
+            "version": "6.17.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/TheDragonCode/support.git",
-                "reference": "b1e076dc23bed84562af97ee03f8bd840a077706"
+                "reference": "82a465953267989883d64b921e9725600a5073b5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/TheDragonCode/support/zipball/b1e076dc23bed84562af97ee03f8bd840a077706",
-                "reference": "b1e076dc23bed84562af97ee03f8bd840a077706",
+                "url": "https://api.github.com/repos/TheDragonCode/support/zipball/82a465953267989883d64b921e9725600a5073b5",
+                "reference": "82a465953267989883d64b921e9725600a5073b5",
                 "shasum": ""
             },
             "require": {
@@ -8101,7 +8110,6 @@
                 "ext-mbstring": "*",
                 "php": "^8.1",
                 "psr/http-message": "^1.0.1 || ^2.0",
-                "symfony/polyfill-php81": "^1.25",
                 "voku/portable-ascii": "^1.4.8 || ^2.0.1"
             },
             "conflict": {
@@ -8171,7 +8179,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-03-18T20:39:32+00:00"
+            "time": "2026-04-03T15:06:29+00:00"
         },
         {
             "name": "fakerphp/faker",
@@ -8481,16 +8489,16 @@
         },
         {
             "name": "laravel-lang/actions",
-            "version": "1.12.1",
+            "version": "1.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/actions.git",
-                "reference": "af2750ace5fd7655b696c39f3f6d0da9ce852d16"
+                "reference": "5e9bbd3b8af3fed4b733e424c56810b0d3e81377"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/actions/zipball/af2750ace5fd7655b696c39f3f6d0da9ce852d16",
-                "reference": "af2750ace5fd7655b696c39f3f6d0da9ce852d16",
+                "url": "https://api.github.com/repos/Laravel-Lang/actions/zipball/5e9bbd3b8af3fed4b733e424c56810b0d3e81377",
+                "reference": "5e9bbd3b8af3fed4b733e424c56810b0d3e81377",
                 "shasum": ""
             },
             "require": {
@@ -8542,7 +8550,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/actions/issues",
-                "source": "https://github.com/Laravel-Lang/actions/tree/1.12.1"
+                "source": "https://github.com/Laravel-Lang/actions/tree/1.13.2"
             },
             "funding": [
                 {
@@ -8554,20 +8562,20 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-03-17T21:27:37+00:00"
+            "time": "2026-05-30T12:11:11+00:00"
         },
         {
             "name": "laravel-lang/attributes",
-            "version": "2.15.4",
+            "version": "2.16.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/attributes.git",
-                "reference": "e922f224d5f20caa4467aec544b8e67b72560cf5"
+                "reference": "4a0de72632bb1862532977fd76ed6be9c1cc65af"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/attributes/zipball/e922f224d5f20caa4467aec544b8e67b72560cf5",
-                "reference": "e922f224d5f20caa4467aec544b8e67b72560cf5",
+                "url": "https://api.github.com/repos/Laravel-Lang/attributes/zipball/4a0de72632bb1862532977fd76ed6be9c1cc65af",
+                "reference": "4a0de72632bb1862532977fd76ed6be9c1cc65af",
                 "shasum": ""
             },
             "require": {
@@ -8621,7 +8629,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/attributes/issues",
-                "source": "https://github.com/Laravel-Lang/attributes/tree/2.15.4"
+                "source": "https://github.com/Laravel-Lang/attributes/tree/2.16.4"
             },
             "funding": [
                 {
@@ -8633,7 +8641,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-03-03T22:33:55+00:00"
+            "time": "2026-05-30T12:11:05+00:00"
         },
         {
             "name": "laravel-lang/common",
@@ -8809,16 +8817,16 @@
         },
         {
             "name": "laravel-lang/http-statuses",
-            "version": "3.12.1",
+            "version": "3.13.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/http-statuses.git",
-                "reference": "4f1cfeb3df179bdcd1c40bb57cc5c7f2a11278b4"
+                "reference": "2d33c7b4f5b268224c559c27c1220764b5391ae2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/http-statuses/zipball/4f1cfeb3df179bdcd1c40bb57cc5c7f2a11278b4",
-                "reference": "4f1cfeb3df179bdcd1c40bb57cc5c7f2a11278b4",
+                "url": "https://api.github.com/repos/Laravel-Lang/http-statuses/zipball/2d33c7b4f5b268224c559c27c1220764b5391ae2",
+                "reference": "2d33c7b4f5b268224c559c27c1220764b5391ae2",
                 "shasum": ""
             },
             "require": {
@@ -8870,7 +8878,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/http-statuses/issues",
-                "source": "https://github.com/Laravel-Lang/http-statuses/tree/3.12.1"
+                "source": "https://github.com/Laravel-Lang/http-statuses/tree/3.13.2"
             },
             "funding": [
                 {
@@ -8882,7 +8890,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-02-05T13:53:17+00:00"
+            "time": "2026-05-30T12:11:06+00:00"
         },
         {
             "name": "laravel-lang/json-fallback",
@@ -8947,16 +8955,16 @@
         },
         {
             "name": "laravel-lang/lang",
-            "version": "15.29.2",
+            "version": "15.31.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/lang.git",
-                "reference": "791087e95fc8525c227f292ea6f6d4867f0bb2dc"
+                "reference": "c4a236543f64cb67bf03e52e85209ee2ca2066e9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/791087e95fc8525c227f292ea6f6d4867f0bb2dc",
-                "reference": "791087e95fc8525c227f292ea6f6d4867f0bb2dc",
+                "url": "https://api.github.com/repos/Laravel-Lang/lang/zipball/c4a236543f64cb67bf03e52e85209ee2ca2066e9",
+                "reference": "c4a236543f64cb67bf03e52e85209ee2ca2066e9",
                 "shasum": ""
             },
             "require": {
@@ -9017,7 +9025,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-03-21T00:27:29+00:00"
+            "time": "2026-06-09T18:10:34+00:00"
         },
         {
             "name": "laravel-lang/locale-list",
@@ -9255,16 +9263,16 @@
         },
         {
             "name": "laravel-lang/moonshine",
-            "version": "1.8.0",
+            "version": "1.9.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/moonshine.git",
-                "reference": "5daace4284fb706f735b172740bce52f990d2359"
+                "reference": "3927bcf658d392c9f2eb03c773f52ff650b37f63"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/moonshine/zipball/5daace4284fb706f735b172740bce52f990d2359",
-                "reference": "5daace4284fb706f735b172740bce52f990d2359",
+                "url": "https://api.github.com/repos/Laravel-Lang/moonshine/zipball/3927bcf658d392c9f2eb03c773f52ff650b37f63",
+                "reference": "3927bcf658d392c9f2eb03c773f52ff650b37f63",
                 "shasum": ""
             },
             "require": {
@@ -9274,7 +9282,7 @@
             },
             "require-dev": {
                 "dragon-code/support": "^6.15.2",
-                "illuminate/support": "^10.0 || ^11.0 || ^12.0",
+                "illuminate/support": "^10.0 || ^11.0 || ^12.0 || ^13.0",
                 "laravel-lang/lang": "^14.8 || ^15.14",
                 "laravel-lang/status-generator": "^2.12",
                 "phpunit/phpunit": "^10.0 || ^11.0 || ^12.0",
@@ -9317,7 +9325,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/moonshine/issues",
-                "source": "https://github.com/Laravel-Lang/moonshine/tree/1.8.0"
+                "source": "https://github.com/Laravel-Lang/moonshine/tree/1.9.2"
             },
             "funding": [
                 {
@@ -9329,7 +9337,7 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-02-01T09:24:41+00:00"
+            "time": "2026-05-30T12:11:41+00:00"
         },
         {
             "name": "laravel-lang/native-country-names",
@@ -9766,16 +9774,16 @@
         },
         {
             "name": "laravel-lang/starter-kits",
-            "version": "1.10.1",
+            "version": "1.16.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/Laravel-Lang/starter-kits.git",
-                "reference": "a99d03b85e59e66e8b5e2da8996eefb80a794446"
+                "reference": "bbe74a48d7623ccb4561f8225ea13cf82e54c9d9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/Laravel-Lang/starter-kits/zipball/a99d03b85e59e66e8b5e2da8996eefb80a794446",
-                "reference": "a99d03b85e59e66e8b5e2da8996eefb80a794446",
+                "url": "https://api.github.com/repos/Laravel-Lang/starter-kits/zipball/bbe74a48d7623ccb4561f8225ea13cf82e54c9d9",
+                "reference": "bbe74a48d7623ccb4561f8225ea13cf82e54c9d9",
                 "shasum": ""
             },
             "require": {
@@ -9827,7 +9835,7 @@
             ],
             "support": {
                 "issues": "https://github.com/Laravel-Lang/starter-kits/issues",
-                "source": "https://github.com/Laravel-Lang/starter-kits/tree/1.10.1"
+                "source": "https://github.com/Laravel-Lang/starter-kits/tree/1.16.0"
             },
             "funding": [
                 {
@@ -9839,20 +9847,20 @@
                     "type": "yoomoney"
                 }
             ],
-            "time": "2026-03-20T08:43:52+00:00"
+            "time": "2026-06-22T19:59:10+00:00"
         },
         {
             "name": "laravel/pail",
-            "version": "v1.2.6",
+            "version": "v1.2.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pail.git",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf"
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pail/zipball/aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
-                "reference": "aa71a01c309e7f66bc2ec4fb1a59291b82eb4abf",
+                "url": "https://api.github.com/repos/laravel/pail/zipball/2f7d27dada8effc48b8c424445a69cca7007daaa",
+                "reference": "2f7d27dada8effc48b8c424445a69cca7007daaa",
                 "shasum": ""
             },
             "require": {
@@ -9919,20 +9927,20 @@
                 "issues": "https://github.com/laravel/pail/issues",
                 "source": "https://github.com/laravel/pail"
             },
-            "time": "2026-02-09T13:44:54+00:00"
+            "time": "2026-05-20T22:24:57+00:00"
         },
         {
             "name": "laravel/pint",
-            "version": "v1.29.0",
+            "version": "v1.29.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/pint.git",
-                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39"
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/pint/zipball/bdec963f53172c5e36330f3a400604c69bf02d39",
-                "reference": "bdec963f53172c5e36330f3a400604c69bf02d39",
+                "url": "https://api.github.com/repos/laravel/pint/zipball/da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
+                "reference": "da1d1111a6aa2e082d2a388b194afe1ba0a05d14",
                 "shasum": ""
             },
             "require": {
@@ -9943,14 +9951,14 @@
                 "php": "^8.2.0"
             },
             "require-dev": {
-                "friendsofphp/php-cs-fixer": "^3.94.2",
-                "illuminate/view": "^12.54.1",
-                "larastan/larastan": "^3.9.3",
-                "laravel-zero/framework": "^12.0.5",
+                "friendsofphp/php-cs-fixer": "^3.95.8",
+                "illuminate/view": "^12.62.0",
+                "larastan/larastan": "^3.10.0",
+                "laravel-zero/framework": "^12.1.0",
+                "laravel/agent-detector": "^2.0.2",
                 "mockery/mockery": "^1.6.12",
                 "nunomaduro/termwind": "^2.4.0",
-                "pestphp/pest": "^3.8.6",
-                "shipfastlabs/agent-detector": "^1.1.0"
+                "pestphp/pest": "^3.8.6"
             },
             "bin": [
                 "builds/pint"
@@ -9987,20 +9995,20 @@
                 "issues": "https://github.com/laravel/pint/issues",
                 "source": "https://github.com/laravel/pint"
             },
-            "time": "2026-03-12T15:51:39+00:00"
+            "time": "2026-06-16T15:34:04+00:00"
         },
         {
             "name": "laravel/sail",
-            "version": "v1.54.0",
+            "version": "v1.63.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/sail.git",
-                "reference": "bcc5e06f1a79d806d880a4b027964d2aa5872b07"
+                "reference": "51bbce3f803c1d386cabbb44e618c955a12ff5fc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/sail/zipball/bcc5e06f1a79d806d880a4b027964d2aa5872b07",
-                "reference": "bcc5e06f1a79d806d880a4b027964d2aa5872b07",
+                "url": "https://api.github.com/repos/laravel/sail/zipball/51bbce3f803c1d386cabbb44e618c955a12ff5fc",
+                "reference": "51bbce3f803c1d386cabbb44e618c955a12ff5fc",
                 "shasum": ""
             },
             "require": {
@@ -10050,7 +10058,7 @@
                 "issues": "https://github.com/laravel/sail/issues",
                 "source": "https://github.com/laravel/sail"
             },
-            "time": "2026-03-11T14:10:52+00:00"
+            "time": "2026-06-18T08:54:14+00:00"
         },
         {
             "name": "mockery/mockery",
@@ -10942,16 +10950,16 @@
         },
         {
             "name": "php-debugbar/php-debugbar",
-            "version": "v3.5.1",
+            "version": "v3.8.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-debugbar/php-debugbar.git",
-                "reference": "486b32fd98efe9a3c10f0b24c0caabc187f78f04"
+                "reference": "18ced90d4b882ed449b2278fea8692f8f7d1c13c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/486b32fd98efe9a3c10f0b24c0caabc187f78f04",
-                "reference": "486b32fd98efe9a3c10f0b24c0caabc187f78f04",
+                "url": "https://api.github.com/repos/php-debugbar/php-debugbar/zipball/18ced90d4b882ed449b2278fea8692f8f7d1c13c",
+                "reference": "18ced90d4b882ed449b2278fea8692f8f7d1c13c",
                 "shasum": ""
             },
             "require": {
@@ -10993,7 +11001,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "3.0-dev"
+                    "dev-master": "3.8-dev"
                 }
             },
             "autoload": {
@@ -11028,7 +11036,7 @@
             ],
             "support": {
                 "issues": "https://github.com/php-debugbar/php-debugbar/issues",
-                "source": "https://github.com/php-debugbar/php-debugbar/tree/v3.5.1"
+                "source": "https://github.com/php-debugbar/php-debugbar/tree/v3.8.0"
             },
             "funding": [
                 {
@@ -11040,7 +11048,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-03-05T20:37:33+00:00"
+            "time": "2026-07-02T12:38:20+00:00"
         },
         {
             "name": "php-debugbar/symfony-bridge",
@@ -12728,97 +12736,17 @@
             "time": "2024-10-20T05:08:20+00:00"
         },
         {
-            "name": "symfony/polyfill-php81",
-            "version": "v1.38.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=7.2"
-            },
-            "type": "library",
-            "extra": {
-                "thanks": {
-                    "url": "https://github.com/symfony/polyfill",
-                    "name": "symfony/polyfill"
-                }
-            },
-            "autoload": {
-                "files": [
-                    "bootstrap.php"
-                ],
-                "psr-4": {
-                    "Symfony\\Polyfill\\Php81\\": ""
-                },
-                "classmap": [
-                    "Resources/stubs"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "MIT"
-            ],
-            "authors": [
-                {
-                    "name": "Nicolas Grekas",
-                    "email": "p@tchwork.com"
-                },
-                {
-                    "name": "Symfony Community",
-                    "homepage": "https://symfony.com/contributors"
-                }
-            ],
-            "description": "Symfony polyfill backporting some PHP 8.1+ features to lower PHP versions",
-            "homepage": "https://symfony.com",
-            "keywords": [
-                "compatibility",
-                "polyfill",
-                "portable",
-                "shim"
-            ],
-            "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
-            },
-            "funding": [
-                {
-                    "url": "https://symfony.com/sponsor",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/fabpot",
-                    "type": "github"
-                },
-                {
-                    "url": "https://github.com/nicolas-grekas",
-                    "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
-                    "type": "tidelift"
-                }
-            ],
-            "time": "2026-05-26T12:45:58+00:00"
-        },
-        {
             "name": "symfony/yaml",
-            "version": "v7.4.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391"
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/58751048de17bae71c5aa0d13cb19d79bca26391",
-                "reference": "58751048de17bae71c5aa0d13cb19d79bca26391",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/f8f328665ace2370d1e10645b807ba1646dc7dcc",
+                "reference": "f8f328665ace2370d1e10645b807ba1646dc7dcc",
                 "shasum": ""
             },
             "require": {
@@ -12861,7 +12789,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.6"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -12881,7 +12809,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "ta-tikoma/phpunit-architecture-test",
@@ -13068,5 +12996,8 @@
         "php": "^8.3"
     },
     "platform-dev": {},
+    "platform-overrides": {
+        "php": "8.3.31"
+    },
     "plugin-api-version": "2.6.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "5e86d6eb489089eabc4ae615e4b07f9a",
+    "content-hash": "537c86c6a87e323f3cdf4ada1e3da5ad",
     "packages": [
         {
             "name": "brick/math",
@@ -715,25 +715,26 @@
         },
         {
             "name": "guzzlehttp/guzzle",
-            "version": "7.10.0",
+            "version": "7.13.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4"
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
-                "reference": "b51ac707cfa420b7bfd4e4d5e510ba8008e822b4",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/55901a76dfd2006a0cc012b9e3c5b487f796478d",
+                "reference": "55901a76dfd2006a0cc012b9e3c5b487f796478d",
                 "shasum": ""
             },
             "require": {
                 "ext-json": "*",
-                "guzzlehttp/promises": "^2.3",
-                "guzzlehttp/psr7": "^2.8",
+                "guzzlehttp/promises": "^2.5",
+                "guzzlehttp/psr7": "^2.12.3",
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-client": "^1.0",
-                "symfony/deprecation-contracts": "^2.2 || ^3.0"
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-client-implementation": "1.0"
@@ -742,8 +743,9 @@
                 "bamarni/composer-bin-plugin": "^1.8.2",
                 "ext-curl": "*",
                 "guzzle/client-integration-tests": "3.0.2",
+                "guzzlehttp/test-server": "^0.6",
                 "php-http/message-factory": "^1.1",
-                "phpunit/phpunit": "^8.5.39 || ^9.6.20",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "psr/log": "^1.1 || ^2.0 || ^3.0"
             },
             "suggest": {
@@ -821,7 +823,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/guzzle/issues",
-                "source": "https://github.com/guzzle/guzzle/tree/7.10.0"
+                "source": "https://github.com/guzzle/guzzle/tree/7.13.1"
             },
             "funding": [
                 {
@@ -837,28 +839,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-23T22:36:01+00:00"
+            "time": "2026-06-29T20:14:18+00:00"
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "2.3.0",
+            "version": "2.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957"
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/481557b130ef3790cf82b713667b43030dc9c957",
-                "reference": "481557b130ef3790cf82b713667b43030dc9c957",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/4360e982f87f5f258bf872d094647791db2f4c8e",
+                "reference": "4360e982f87f5f258bf872d094647791db2f4c8e",
                 "shasum": ""
             },
             "require": {
-                "php": "^7.2.5 || ^8.0"
+                "php": "^7.2.5 || ^8.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "type": "library",
             "extra": {
@@ -904,7 +907,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/2.3.0"
+                "source": "https://github.com/guzzle/promises/tree/2.5.0"
             },
             "funding": [
                 {
@@ -920,27 +923,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:34:08+00:00"
+            "time": "2026-06-02T12:23:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.12.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
+                "reference": "7ec62dc3f44aa218487dbed81a9bf9bc647be55d",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
                 "psr/http-factory": "^1.0",
                 "psr/http-message": "^1.1 || ^2.0",
-                "ralouphie/getallheaders": "^3.0"
+                "ralouphie/getallheaders": "^3.0",
+                "symfony/deprecation-contracts": "^2.5 || ^3.0",
+                "symfony/polyfill-php80": "^1.25"
             },
             "provide": {
                 "psr/http-factory-implementation": "1.0",
@@ -948,9 +953,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -1021,7 +1026,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.12.3"
             },
             "funding": [
                 {
@@ -1037,29 +1042,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-06-23T15:21:08+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",
-            "version": "v1.0.5",
+            "version": "v1.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/uri-template.git",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1"
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/4f4bbd4e7172148801e76e3decc1e559bdee34e1",
-                "reference": "4f4bbd4e7172148801e76e3decc1e559bdee34e1",
+                "url": "https://api.github.com/repos/guzzle/uri-template/zipball/9c19128923b05a5d7355e5d2318d7808b7e33bbd",
+                "reference": "9c19128923b05a5d7355e5d2318d7808b7e33bbd",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.2.5 || ^8.0",
-                "symfony/polyfill-php80": "^1.24"
+                "symfony/polyfill-php80": "^1.25"
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25",
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34",
                 "uri-template/tests": "1.0.0"
             },
             "type": "library",
@@ -1107,7 +1112,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/uri-template/issues",
-                "source": "https://github.com/guzzle/uri-template/tree/v1.0.5"
+                "source": "https://github.com/guzzle/uri-template/tree/v1.0.8"
             },
             "funding": [
                 {
@@ -1123,7 +1128,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-22T14:27:06+00:00"
+            "time": "2026-06-23T13:02:23+00:00"
         },
         {
             "name": "hisorange/browser-detect",
@@ -1536,16 +1541,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v12.55.1",
+            "version": "v12.62.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "6d9185a248d101b07eecaf8fd60b18129545fd33"
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/6d9185a248d101b07eecaf8fd60b18129545fd33",
-                "reference": "6d9185a248d101b07eecaf8fd60b18129545fd33",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/f7e61eb1e0e06a38996802b769bce9127aec227c",
+                "reference": "f7e61eb1e0e06a38996802b769bce9127aec227c",
                 "shasum": ""
             },
             "require": {
@@ -1586,8 +1591,8 @@
                 "symfony/mailer": "^7.2.0",
                 "symfony/mime": "^7.2.0",
                 "symfony/polyfill-php83": "^1.33",
-                "symfony/polyfill-php84": "^1.33",
-                "symfony/polyfill-php85": "^1.33",
+                "symfony/polyfill-php84": "^1.34",
+                "symfony/polyfill-php85": "^1.34",
                 "symfony/process": "^7.2.0",
                 "symfony/routing": "^7.2.0",
                 "symfony/uid": "^7.2.0",
@@ -1754,20 +1759,20 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2026-03-18T14:28:59+00:00"
+            "time": "2026-06-09T13:50:13+00:00"
         },
         {
             "name": "laravel/prompts",
-            "version": "v0.3.15",
+            "version": "v0.3.21",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/prompts.git",
-                "reference": "4bb8107ec97651fd3f17f897d6489dbc4d8fb999"
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/prompts/zipball/4bb8107ec97651fd3f17f897d6489dbc4d8fb999",
-                "reference": "4bb8107ec97651fd3f17f897d6489dbc4d8fb999",
+                "url": "https://api.github.com/repos/laravel/prompts/zipball/7753c65c281c2550c7c183f14e18062073b7d821",
+                "reference": "7753c65c281c2550c7c183f14e18062073b7d821",
                 "shasum": ""
             },
             "require": {
@@ -1811,22 +1816,22 @@
             "description": "Add beautiful and user-friendly forms to your command-line applications.",
             "support": {
                 "issues": "https://github.com/laravel/prompts/issues",
-                "source": "https://github.com/laravel/prompts/tree/v0.3.15"
+                "source": "https://github.com/laravel/prompts/tree/v0.3.21"
             },
-            "time": "2026-03-17T13:45:17+00:00"
+            "time": "2026-06-26T00:11:25+00:00"
         },
         {
             "name": "laravel/serializable-closure",
-            "version": "v2.0.10",
+            "version": "v2.0.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/serializable-closure.git",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669"
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/870fc81d2f879903dfc5b60bf8a0f94a1609e669",
-                "reference": "870fc81d2f879903dfc5b60bf8a0f94a1609e669",
+                "url": "https://api.github.com/repos/laravel/serializable-closure/zipball/b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
+                "reference": "b566ee0dd251f3c4078bed003a7ce015f5ea6dce",
                 "shasum": ""
             },
             "require": {
@@ -1874,7 +1879,7 @@
                 "issues": "https://github.com/laravel/serializable-closure/issues",
                 "source": "https://github.com/laravel/serializable-closure"
             },
-            "time": "2026-02-20T19:59:49+00:00"
+            "time": "2026-04-16T14:03:50+00:00"
         },
         {
             "name": "laravel/tinker",
@@ -2196,16 +2201,16 @@
         },
         {
             "name": "league/flysystem",
-            "version": "3.32.0",
+            "version": "3.35.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/flysystem.git",
-                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725"
+                "reference": "f23af6c5aafd958a7593029a271d77baf5ed793c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/254b1595b16b22dbddaaef9ed6ca9fdac4956725",
-                "reference": "254b1595b16b22dbddaaef9ed6ca9fdac4956725",
+                "url": "https://api.github.com/repos/thephpleague/flysystem/zipball/f23af6c5aafd958a7593029a271d77baf5ed793c",
+                "reference": "f23af6c5aafd958a7593029a271d77baf5ed793c",
                 "shasum": ""
             },
             "require": {
@@ -2273,9 +2278,9 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/flysystem/issues",
-                "source": "https://github.com/thephpleague/flysystem/tree/3.32.0"
+                "source": "https://github.com/thephpleague/flysystem/tree/3.35.1"
             },
-            "time": "2026-02-25T17:01:41+00:00"
+            "time": "2026-06-25T06:52:23+00:00"
         },
         {
             "name": "league/flysystem-local",
@@ -2622,16 +2627,16 @@
         },
         {
             "name": "livewire/livewire",
-            "version": "v4.2.1",
+            "version": "v4.3.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/livewire/livewire.git",
-                "reference": "93e972fa42c1b34fff1550093ab94f778d81ea5a"
+                "reference": "8021f2561865c4c297a3bfca37212a99034377e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/livewire/livewire/zipball/93e972fa42c1b34fff1550093ab94f778d81ea5a",
-                "reference": "93e972fa42c1b34fff1550093ab94f778d81ea5a",
+                "url": "https://api.github.com/repos/livewire/livewire/zipball/8021f2561865c4c297a3bfca37212a99034377e7",
+                "reference": "8021f2561865c4c297a3bfca37212a99034377e7",
                 "shasum": ""
             },
             "require": {
@@ -2686,7 +2691,7 @@
             "description": "A front-end framework for Laravel.",
             "support": {
                 "issues": "https://github.com/livewire/livewire/issues",
-                "source": "https://github.com/livewire/livewire/tree/v4.2.1"
+                "source": "https://github.com/livewire/livewire/tree/v4.3.3"
             },
             "funding": [
                 {
@@ -2694,7 +2699,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-02-28T00:01:19+00:00"
+            "time": "2026-06-27T03:16:11+00:00"
         },
         {
             "name": "matomo/device-detector",
@@ -2988,16 +2993,16 @@
         },
         {
             "name": "nesbot/carbon",
-            "version": "3.11.3",
+            "version": "3.13.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/CarbonPHP/carbon.git",
-                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf"
+                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/6a7e652845bb018c668220c2a545aded8594fbbf",
-                "reference": "6a7e652845bb018c668220c2a545aded8594fbbf",
+                "url": "https://api.github.com/repos/CarbonPHP/carbon/zipball/40f6618f052df16b545f626fbf9a878e6497d16a",
+                "reference": "40f6618f052df16b545f626fbf9a878e6497d16a",
                 "shasum": ""
             },
             "require": {
@@ -3089,7 +3094,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-11T17:23:39+00:00"
+            "time": "2026-06-18T13:49:15+00:00"
         },
         {
             "name": "nette/schema",
@@ -3160,16 +3165,16 @@
         },
         {
             "name": "nette/utils",
-            "version": "v4.1.3",
+            "version": "v4.1.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nette/utils.git",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe"
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nette/utils/zipball/bb3ea637e3d131d72acc033cfc2746ee893349fe",
-                "reference": "bb3ea637e3d131d72acc033cfc2746ee893349fe",
+                "url": "https://api.github.com/repos/nette/utils/zipball/7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
+                "reference": "7da6c396d7ebe142bc857c20479d5e70a5e1aac7",
                 "shasum": ""
             },
             "require": {
@@ -3245,9 +3250,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nette/utils/issues",
-                "source": "https://github.com/nette/utils/tree/v4.1.3"
+                "source": "https://github.com/nette/utils/tree/v4.1.4"
             },
-            "time": "2026-02-13T03:05:33+00:00"
+            "time": "2026-05-11T20:49:54+00:00"
         },
         {
             "name": "nikic/php-parser",
@@ -4434,20 +4439,20 @@
         },
         {
             "name": "ramsey/uuid",
-            "version": "4.9.2",
+            "version": "4.9.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/ramsey/uuid.git",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0"
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/ramsey/uuid/zipball/8429c78ca35a09f27565311b98101e2826affde0",
-                "reference": "8429c78ca35a09f27565311b98101e2826affde0",
+                "url": "https://api.github.com/repos/ramsey/uuid/zipball/1df15849d00943a67d677dc9cfd80795f038c9f8",
+                "reference": "1df15849d00943a67d677dc9cfd80795f038c9f8",
                 "shasum": ""
             },
             "require": {
-                "brick/math": "^0.8.16 || ^0.9 || ^0.10 || ^0.11 || ^0.12 || ^0.13 || ^0.14",
+                "brick/math": ">=0.8.16 <=0.18",
                 "php": "^8.0",
                 "ramsey/collection": "^1.2 || ^2.0"
             },
@@ -4506,28 +4511,27 @@
             ],
             "support": {
                 "issues": "https://github.com/ramsey/uuid/issues",
-                "source": "https://github.com/ramsey/uuid/tree/4.9.2"
+                "source": "https://github.com/ramsey/uuid/tree/4.9.3"
             },
-            "time": "2025-12-14T04:43:48+00:00"
+            "time": "2026-06-18T03:57:49+00:00"
         },
         {
             "name": "symfony/clock",
-            "version": "v7.4.0",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/clock.git",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110"
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/clock/zipball/9169f24776edde469914c1e7a1442a50f7a4e110",
-                "reference": "9169f24776edde469914c1e7a1442a50f7a4e110",
+                "url": "https://api.github.com/repos/symfony/clock/zipball/701ef4de9705d6c32292ebee5e8044094a09fbf6",
+                "reference": "701ef4de9705d6c32292ebee5e8044094a09fbf6",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "psr/clock": "^1.0",
-                "symfony/polyfill-php83": "^1.28"
+                "php": ">=8.4.1",
+                "psr/clock": "^1.0"
             },
             "provide": {
                 "psr/clock-implementation": "1.0"
@@ -4566,7 +4570,7 @@
                 "time"
             ],
             "support": {
-                "source": "https://github.com/symfony/clock/tree/v7.4.0"
+                "source": "https://github.com/symfony/clock/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4586,20 +4590,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-11-12T15:39:26+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.7",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d"
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/e1e6770440fb9c9b0cf725f81d1361ad1835329d",
-                "reference": "e1e6770440fb9c9b0cf725f81d1361ad1835329d",
+                "url": "https://api.github.com/repos/symfony/console/zipball/92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
+                "reference": "92f58bc4bf97a92ed1b9f367f0cd44f20bde0e87",
                 "shasum": ""
             },
             "require": {
@@ -4664,7 +4668,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.7"
+                "source": "https://github.com/symfony/console/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4684,24 +4688,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T14:06:20+00:00"
+            "time": "2026-06-16T11:50:14+00:00"
         },
         {
             "name": "symfony/css-selector",
-            "version": "v7.4.6",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/css-selector.git",
-                "reference": "2e7c52c647b406e2107dd867db424a4dbac91864"
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/css-selector/zipball/2e7c52c647b406e2107dd867db424a4dbac91864",
-                "reference": "2e7c52c647b406e2107dd867db424a4dbac91864",
+                "url": "https://api.github.com/repos/symfony/css-selector/zipball/dc0e2be45c9b5588c82414f02ac574b4b986abcd",
+                "reference": "dc0e2be45c9b5588c82414f02ac574b4b986abcd",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4.1"
             },
             "type": "library",
             "autoload": {
@@ -4733,7 +4737,7 @@
             "description": "Converts CSS selectors to XPath expressions",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/css-selector/tree/v7.4.6"
+                "source": "https://github.com/symfony/css-selector/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -4753,20 +4757,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T07:53:42+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62"
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/63afe740e99a13ba87ec199bb07bbdee937a5b62",
-                "reference": "63afe740e99a13ba87ec199bb07bbdee937a5b62",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/f3202fa1b5097b0af062dc978b32ecf63404e31d",
+                "reference": "f3202fa1b5097b0af062dc978b32ecf63404e31d",
                 "shasum": ""
             },
             "require": {
@@ -4779,7 +4783,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -4804,7 +4808,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -4816,24 +4820,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/error-handler",
-            "version": "v7.4.4",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8"
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/8da531f364ddfee53e36092a7eebbbd0b775f6b8",
-                "reference": "8da531f364ddfee53e36092a7eebbbd0b775f6b8",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/4e1a093b481f323e6e326451f9760c3868430673",
+                "reference": "4e1a093b481f323e6e326451f9760c3868430673",
                 "shasum": ""
             },
             "require": {
@@ -4882,7 +4890,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v7.4.4"
+                "source": "https://github.com/symfony/error-handler/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -4902,28 +4910,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-20T16:42:42+00:00"
+            "time": "2026-06-05T06:22:21+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.4",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746"
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/dc2c0eba1af673e736bb851d747d266108aea746",
-                "reference": "dc2c0eba1af673e736bb851d747d266108aea746",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/abd6c11dc468725d1627302ad10f6cd486e9e3d0",
+                "reference": "abd6c11dc468725d1627302ad10f6cd486e9e3d0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4.1",
+                "symfony/deprecation-contracts": "^2.5|^3",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -4932,14 +4941,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -4967,7 +4976,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.4"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -4987,20 +4996,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-05T11:45:34+00:00"
+            "time": "2026-06-09T12:28:30+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.6.0",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586"
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/59eb412e93815df44f05f342958efa9f46b1e586",
-                "reference": "59eb412e93815df44f05f342958efa9f46b1e586",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/c7de7a00ffb67842132da02ea92988a39ccd9f4e",
+                "reference": "c7de7a00ffb67842132da02ea92988a39ccd9f4e",
                 "shasum": ""
             },
             "require": {
@@ -5014,7 +5023,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -5047,7 +5056,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.6.0"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -5059,24 +5068,28 @@
                     "type": "github"
                 },
                 {
+                    "url": "https://github.com/nicolas-grekas",
+                    "type": "github"
+                },
+                {
                     "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-25T14:21:43+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf"
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
-                "reference": "8655bf1076b7a3a346cb11413ffdabff50c7ffcf",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/13b38720174286f55d1761152b575a8d1436fc25",
+                "reference": "13b38720174286f55d1761152b575a8d1436fc25",
                 "shasum": ""
             },
             "require": {
@@ -5111,7 +5124,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.6"
+                "source": "https://github.com/symfony/finder/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5131,20 +5144,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-29T09:40:50+00:00"
+            "time": "2026-06-27T08:31:18+00:00"
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v7.4.7",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81"
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
-                "reference": "f94b3e7b7dafd40e666f0c9ff2084133bae41e81",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/06db5ae1552177bf8572f8908839f12e3c06aed3",
+                "reference": "06db5ae1552177bf8572f8908839f12e3c06aed3",
                 "shasum": ""
             },
             "require": {
@@ -5193,7 +5206,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-foundation/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5213,20 +5226,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T13:15:18+00:00"
+            "time": "2026-06-11T07:31:44+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v7.4.7",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1"
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/3b3fcf386c809be990c922e10e4c620d6367cab1",
-                "reference": "3b3fcf386c809be990c922e10e4c620d6367cab1",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/e99af79b1e776646eda0e1c23b7b45c184ff99be",
+                "reference": "e99af79b1e776646eda0e1c23b7b45c184ff99be",
                 "shasum": ""
             },
             "require": {
@@ -5312,7 +5325,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v7.4.7"
+                "source": "https://github.com/symfony/http-kernel/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5332,20 +5345,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-06T16:33:18+00:00"
+            "time": "2026-06-27T09:14:35+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v7.4.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9"
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
-                "reference": "b02726f39a20bc65e30364f5c750c4ddbf1f58e9",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/f88ce03ae73e3edb5c176ce1f337709996e88495",
+                "reference": "f88ce03ae73e3edb5c176ce1f337709996e88495",
                 "shasum": ""
             },
             "require": {
@@ -5396,7 +5409,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v7.4.6"
+                "source": "https://github.com/symfony/mailer/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -5416,20 +5429,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-06-13T08:51:35+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v7.4.7",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1"
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
-                "reference": "da5ab4fde3f6c88ab06e96185b9922f48b677cd1",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/a845722765c4f6b2ce88beaf4f4479975b186770",
+                "reference": "a845722765c4f6b2ce88beaf4f4479975b186770",
                 "shasum": ""
             },
             "require": {
@@ -5485,7 +5498,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v7.4.7"
+                "source": "https://github.com/symfony/mime/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -5505,20 +5518,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-05T15:24:09+00:00"
+            "time": "2026-05-23T16:22:37+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-ctype.git",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638"
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/a3cc8b044a6ea513310cbd48ef7333b384945638",
-                "reference": "a3cc8b044a6ea513310cbd48ef7333b384945638",
+                "url": "https://api.github.com/repos/symfony/polyfill-ctype/zipball/141046a8f9477948ff284fa65be2095baafb94f2",
+                "reference": "141046a8f9477948ff284fa65be2095baafb94f2",
                 "shasum": ""
             },
             "require": {
@@ -5568,7 +5581,7 @@
                 "portable"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-ctype/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -5588,20 +5601,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-grapheme.git",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70"
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/380872130d3a5dd3ace2f4010d95125fde5d5c70",
-                "reference": "380872130d3a5dd3ace2f4010d95125fde5d5c70",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-grapheme/zipball/e9247d281d694a5120554d9afaf54e070e88a603",
+                "reference": "e9247d281d694a5120554d9afaf54e070e88a603",
                 "shasum": ""
             },
             "require": {
@@ -5650,7 +5663,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-grapheme/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5670,20 +5683,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-27T09:58:17+00:00"
+            "time": "2026-05-26T05:58:03+00:00"
         },
         {
             "name": "symfony/polyfill-intl-idn",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-idn.git",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3"
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/9614ac4d8061dc257ecc64cba1b140873dce8ad3",
-                "reference": "9614ac4d8061dc257ecc64cba1b140873dce8ad3",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-idn/zipball/dc21118016c039a66235cf93d96b435ffb282412",
+                "reference": "dc21118016c039a66235cf93d96b435ffb282412",
                 "shasum": ""
             },
             "require": {
@@ -5737,7 +5750,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-idn/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -5757,20 +5770,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-10T14:38:51+00:00"
+            "time": "2026-05-25T15:22:23+00:00"
         },
         {
             "name": "symfony/polyfill-intl-normalizer",
-            "version": "v1.33.0",
+            "version": "v1.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-intl-normalizer.git",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c"
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/3833d7255cc303546435cb650316bff708a1c75c",
-                "reference": "3833d7255cc303546435cb650316bff708a1c75c",
+                "url": "https://api.github.com/repos/symfony/polyfill-intl-normalizer/zipball/2d446c214bdbe5b71bde5011b060a05fece3ae6b",
+                "reference": "2d446c214bdbe5b71bde5011b060a05fece3ae6b",
                 "shasum": ""
             },
             "require": {
@@ -5822,7 +5835,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-intl-normalizer/tree/v1.38.0"
             },
             "funding": [
                 {
@@ -5842,20 +5855,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-25T13:48:31+00:00"
         },
         {
             "name": "symfony/polyfill-mbstring",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-mbstring.git",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493"
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/6d857f4d76bd4b343eac26d6b539585d2bc56493",
-                "reference": "6d857f4d76bd4b343eac26d6b539585d2bc56493",
+                "url": "https://api.github.com/repos/symfony/polyfill-mbstring/zipball/d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
+                "reference": "d3d318bad5e7a1bfbd026009c8bfb8d8f99ae6b6",
                 "shasum": ""
             },
             "require": {
@@ -5907,7 +5920,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-mbstring/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -5927,20 +5940,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-12-23T08:48:59+00:00"
+            "time": "2026-05-27T06:59:30+00:00"
         },
         {
             "name": "symfony/polyfill-php80",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php80.git",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608"
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
-                "reference": "0cc9dd0f17f61d8131e7df6b84bd344899fe2608",
+                "url": "https://api.github.com/repos/symfony/polyfill-php80/zipball/dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
+                "reference": "dfb55726c3a76ea3b6459fcfda1ec2d80a682411",
                 "shasum": ""
             },
             "require": {
@@ -5991,7 +6004,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php80/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php80/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6011,20 +6024,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-01-02T08:10:11+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/polyfill-php83",
-            "version": "v1.33.0",
+            "version": "v1.38.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php83.git",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5"
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/17f6f9a6b1735c0f163024d959f700cfbc5155e5",
-                "reference": "17f6f9a6b1735c0f163024d959f700cfbc5155e5",
+                "url": "https://api.github.com/repos/symfony/polyfill-php83/zipball/796a26abb75ce49f3a84433cd81bf1009d73d5f8",
+                "reference": "796a26abb75ce49f3a84433cd81bf1009d73d5f8",
                 "shasum": ""
             },
             "require": {
@@ -6071,7 +6084,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php83/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php83/tree/v1.38.2"
             },
             "funding": [
                 {
@@ -6091,20 +6104,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-08T02:45:35+00:00"
+            "time": "2026-05-27T06:51:48+00:00"
         },
         {
             "name": "symfony/polyfill-php84",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php84.git",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191"
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/d8ced4d875142b6a7426000426b8abc631d6b191",
-                "reference": "d8ced4d875142b6a7426000426b8abc631d6b191",
+                "url": "https://api.github.com/repos/symfony/polyfill-php84/zipball/f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
+                "reference": "f4e1dfaee5b74aba5964fe1fd4dfc7ba5e3085fa",
                 "shasum": ""
             },
             "require": {
@@ -6151,7 +6164,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php84/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php84/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6171,20 +6184,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-24T13:30:11+00:00"
+            "time": "2026-05-26T12:51:13+00:00"
         },
         {
             "name": "symfony/polyfill-php85",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php85.git",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91"
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
-                "reference": "d4e5fcd4ab3d998ab16c0db48e6cbb9a01993f91",
+                "url": "https://api.github.com/repos/symfony/polyfill-php85/zipball/ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
+                "reference": "ba2ba04f3352cfa2dcbbcb90aee13ed967f505b1",
                 "shasum": ""
             },
             "require": {
@@ -6231,7 +6244,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php85/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php85/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -6251,20 +6264,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-06-23T16:12:55+00:00"
+            "time": "2026-05-26T02:25:22+00:00"
         },
         {
             "name": "symfony/polyfill-uuid",
-            "version": "v1.33.0",
+            "version": "v1.37.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-uuid.git",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2"
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
-                "reference": "21533be36c24be3f4b1669c4725c7d1d2bab4ae2",
+                "url": "https://api.github.com/repos/symfony/polyfill-uuid/zipball/26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
+                "reference": "26dfec253c4cf3e51b541b52ddf7e42cb0908e94",
                 "shasum": ""
             },
             "require": {
@@ -6314,7 +6327,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-uuid/tree/v1.37.0"
             },
             "funding": [
                 {
@@ -6334,20 +6347,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-04-10T16:19:22+00:00"
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.5",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97"
+                "reference": "f5804be144caceb570f6747519999636b664f24c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/608476f4604102976d687c483ac63a79ba18cc97",
-                "reference": "608476f4604102976d687c483ac63a79ba18cc97",
+                "url": "https://api.github.com/repos/symfony/process/zipball/f5804be144caceb570f6747519999636b664f24c",
+                "reference": "f5804be144caceb570f6747519999636b664f24c",
                 "shasum": ""
             },
             "require": {
@@ -6379,7 +6392,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.5"
+                "source": "https://github.com/symfony/process/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6399,20 +6412,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-26T15:07:59+00:00"
+            "time": "2026-05-23T16:05:06+00:00"
         },
         {
             "name": "symfony/routing",
-            "version": "v7.4.6",
+            "version": "v7.4.13",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938"
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/238d749c56b804b31a9bf3e26519d93b65a60938",
-                "reference": "238d749c56b804b31a9bf3e26519d93b65a60938",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/3a162171bb008e5e0f15dce6581373a4c0e8390d",
+                "reference": "3a162171bb008e5e0f15dce6581373a4c0e8390d",
                 "shasum": ""
             },
             "require": {
@@ -6464,7 +6477,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v7.4.6"
+                "source": "https://github.com/symfony/routing/tree/v7.4.13"
             },
             "funding": [
                 {
@@ -6484,20 +6497,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-25T16:50:00+00:00"
+            "time": "2026-05-24T11:20:33+00:00"
         },
         {
             "name": "symfony/service-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/service-contracts.git",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43"
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/45112560a3ba2d715666a509a0bc9521d10b6c43",
-                "reference": "45112560a3ba2d715666a509a0bc9521d10b6c43",
+                "url": "https://api.github.com/repos/symfony/service-contracts/zipball/c0a284bab1ed8aa0417e3d69250ab437739563a0",
+                "reference": "c0a284bab1ed8aa0417e3d69250ab437739563a0",
                 "shasum": ""
             },
             "require": {
@@ -6515,7 +6528,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6551,7 +6564,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/service-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/service-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6571,39 +6584,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T11:30:57+00:00"
+            "time": "2026-06-16T09:55:08+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.6",
+            "version": "v8.1.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b"
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/9f209231affa85aa930a5e46e6eb03381424b30b",
-                "reference": "9f209231affa85aa930a5e46e6eb03381424b30b",
+                "url": "https://api.github.com/repos/symfony/string/zipball/afd5944f4005862d961efb85c8bbd5c523c4e3c9",
+                "reference": "afd5944f4005862d961efb85c8bbd5c523c4e3c9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4.1",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6642,7 +6654,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.6"
+                "source": "https://github.com/symfony/string/tree/v8.1.0"
             },
             "funding": [
                 {
@@ -6662,38 +6674,31 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-09T09:33:46+00:00"
+            "time": "2026-05-29T05:06:50+00:00"
         },
         {
             "name": "symfony/translation",
-            "version": "v7.4.6",
+            "version": "v8.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation.git",
-                "reference": "1888cf064399868af3784b9e043240f1d89d25ce"
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation/zipball/1888cf064399868af3784b9e043240f1d89d25ce",
-                "reference": "1888cf064399868af3784b9e043240f1d89d25ce",
+                "url": "https://api.github.com/repos/symfony/translation/zipball/342b4218630dc2cf284cedcb2080c80b13404014",
+                "reference": "342b4218630dc2cf284cedcb2080c80b13404014",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
-                "symfony/translation-contracts": "^2.5.3|^3.3"
+                "php": ">=8.4.1",
+                "symfony/polyfill-mbstring": "^1.0",
+                "symfony/translation-contracts": "^3.6.1"
             },
             "conflict": {
                 "nikic/php-parser": "<5.0",
-                "symfony/config": "<6.4",
-                "symfony/console": "<6.4",
-                "symfony/dependency-injection": "<6.4",
                 "symfony/http-client-contracts": "<2.5",
-                "symfony/http-kernel": "<6.4",
-                "symfony/service-contracts": "<2.5",
-                "symfony/twig-bundle": "<6.4",
-                "symfony/yaml": "<6.4"
+                "symfony/service-contracts": "<2.5"
             },
             "provide": {
                 "symfony/translation-implementation": "2.3|3.0"
@@ -6701,17 +6706,17 @@
             "require-dev": {
                 "nikic/php-parser": "^5.0",
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/console": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/finder": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/console": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/finder": "^7.4|^8.0",
                 "symfony/http-client-contracts": "^2.5|^3.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/polyfill-intl-icu": "^1.21",
-                "symfony/routing": "^6.4|^7.0|^8.0",
+                "symfony/routing": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/yaml": "^6.4|^7.0|^8.0"
+                "symfony/yaml": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -6742,7 +6747,7 @@
             "description": "Provides tools to internationalize your application",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/translation/tree/v7.4.6"
+                "source": "https://github.com/symfony/translation/tree/v8.1.1"
             },
             "funding": [
                 {
@@ -6762,20 +6767,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-17T07:53:42+00:00"
+            "time": "2026-06-06T11:11:44+00:00"
         },
         {
             "name": "symfony/translation-contracts",
-            "version": "v3.6.1",
+            "version": "v3.7.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/translation-contracts.git",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977"
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/65a8bc82080447fae78373aa10f8d13b38338977",
-                "reference": "65a8bc82080447fae78373aa10f8d13b38338977",
+                "url": "https://api.github.com/repos/symfony/translation-contracts/zipball/ccb206b98faccc511ebae8e5fad50f2dc0b30621",
+                "reference": "ccb206b98faccc511ebae8e5fad50f2dc0b30621",
                 "shasum": ""
             },
             "require": {
@@ -6788,7 +6793,7 @@
                     "name": "symfony/contracts"
                 },
                 "branch-alias": {
-                    "dev-main": "3.6-dev"
+                    "dev-main": "3.7-dev"
                 }
             },
             "autoload": {
@@ -6824,7 +6829,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/translation-contracts/tree/v3.6.1"
+                "source": "https://github.com/symfony/translation-contracts/tree/v3.7.1"
             },
             "funding": [
                 {
@@ -6844,20 +6849,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-07-15T13:41:35+00:00"
+            "time": "2026-06-05T06:23:12+00:00"
         },
         {
             "name": "symfony/uid",
-            "version": "v7.4.4",
+            "version": "v7.4.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/uid.git",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36"
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/uid/zipball/7719ce8aba76be93dfe249192f1fbfa52c588e36",
-                "reference": "7719ce8aba76be93dfe249192f1fbfa52c588e36",
+                "url": "https://api.github.com/repos/symfony/uid/zipball/2676b524340abcfe4d6151ec698463cebafee439",
+                "reference": "2676b524340abcfe4d6151ec698463cebafee439",
                 "shasum": ""
             },
             "require": {
@@ -6902,7 +6907,7 @@
                 "uuid"
             ],
             "support": {
-                "source": "https://github.com/symfony/uid/tree/v7.4.4"
+                "source": "https://github.com/symfony/uid/tree/v7.4.9"
             },
             "funding": [
                 {
@@ -6922,20 +6927,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-03T23:30:35+00:00"
+            "time": "2026-04-30T15:19:22+00:00"
         },
         {
             "name": "symfony/var-dumper",
-            "version": "v7.4.6",
+            "version": "v7.4.14",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/var-dumper.git",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291"
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/045321c440ac18347b136c63d2e9bf28a2dc0291",
-                "reference": "045321c440ac18347b136c63d2e9bf28a2dc0291",
+                "url": "https://api.github.com/repos/symfony/var-dumper/zipball/9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
+                "reference": "9a3a56a4a1e65a5cb4f8d13801fe8ab0a170e358",
                 "shasum": ""
             },
             "require": {
@@ -6989,7 +6994,7 @@
                 "dump"
             ],
             "support": {
-                "source": "https://github.com/symfony/var-dumper/tree/v7.4.6"
+                "source": "https://github.com/symfony/var-dumper/tree/v7.4.14"
             },
             "funding": [
                 {
@@ -7009,7 +7014,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-15T10:53:20+00:00"
+            "time": "2026-06-08T20:24:16+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",
@@ -7215,23 +7220,23 @@
         },
         {
             "name": "voku/portable-ascii",
-            "version": "2.0.3",
+            "version": "2.1.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/voku/portable-ascii.git",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d"
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
-                "reference": "b1d923f88091c6bf09699efcd7c8a1b1bfd7351d",
+                "url": "https://api.github.com/repos/voku/portable-ascii/zipball/8e1051fe39379367aecf014f41744ce7539a856f",
+                "reference": "8e1051fe39379367aecf014f41744ce7539a856f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=7.0.0"
+                "php": ">=7.1.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "~6.0 || ~7.0 || ~9.0"
+                "phpunit/phpunit": "~8.5 || ~9.6 || ~10.5 || ~11.5"
             },
             "suggest": {
                 "ext-intl": "Use Intl for transliterator_transliterate() support"
@@ -7261,7 +7266,7 @@
             ],
             "support": {
                 "issues": "https://github.com/voku/portable-ascii/issues",
-                "source": "https://github.com/voku/portable-ascii/tree/2.0.3"
+                "source": "https://github.com/voku/portable-ascii/tree/2.1.1"
             },
             "funding": [
                 {
@@ -7285,7 +7290,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-11-21T01:49:47+00:00"
+            "time": "2026-04-26T05:33:54+00:00"
         }
     ],
     "packages-dev": [
@@ -7442,6 +7447,99 @@
             "time": "2026-03-09T14:55:04+00:00"
         },
         {
+            "name": "brianium/paratest",
+            "version": "v7.20.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/paratestphp/paratest.git",
+                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/paratestphp/paratest/zipball/81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
+                "reference": "81c80677c9ec0ed4ef16b246167f11dec81a6e3d",
+                "shasum": ""
+            },
+            "require": {
+                "ext-dom": "*",
+                "ext-pcre": "*",
+                "ext-reflection": "*",
+                "ext-simplexml": "*",
+                "fidry/cpu-core-counter": "^1.3.0",
+                "jean85/pretty-package-versions": "^2.1.1",
+                "php": "~8.3.0 || ~8.4.0 || ~8.5.0",
+                "phpunit/php-code-coverage": "^12.5.3 || ^13.0.1",
+                "phpunit/php-file-iterator": "^6.0.1 || ^7",
+                "phpunit/php-timer": "^8 || ^9",
+                "phpunit/phpunit": "^12.5.14 || ^13.0.5",
+                "sebastian/environment": "^8.0.3 || ^9",
+                "symfony/console": "^7.4.7 || ^8.0.7",
+                "symfony/process": "^7.4.5 || ^8.0.5"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^14.0.0",
+                "ext-pcntl": "*",
+                "ext-pcov": "*",
+                "ext-posix": "*",
+                "phpstan/phpstan": "^2.1.44",
+                "phpstan/phpstan-deprecation-rules": "^2.0.4",
+                "phpstan/phpstan-phpunit": "^2.0.16",
+                "phpstan/phpstan-strict-rules": "^2.0.10",
+                "symfony/filesystem": "^7.4.6 || ^8.0.6"
+            },
+            "bin": [
+                "bin/paratest",
+                "bin/paratest_for_phpstorm"
+            ],
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "ParaTest\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Brian Scaturro",
+                    "email": "scaturrob@gmail.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Filippo Tessarotto",
+                    "email": "zoeslam@gmail.com",
+                    "role": "Developer"
+                }
+            ],
+            "description": "Parallel testing for PHP",
+            "homepage": "https://github.com/paratestphp/paratest",
+            "keywords": [
+                "concurrent",
+                "parallel",
+                "phpunit",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/paratestphp/paratest/issues",
+                "source": "https://github.com/paratestphp/paratest/tree/v7.20.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/Slamdunk",
+                    "type": "github"
+                },
+                {
+                    "url": "https://paypal.me/filippotessarotto",
+                    "type": "paypal"
+                }
+            ],
+            "time": "2026-03-29T15:46:14+00:00"
+        },
+        {
             "name": "codezero/browser-locale",
             "version": "3.4.0",
             "source": {
@@ -7582,28 +7680,29 @@
         },
         {
             "name": "composer/pcre",
-            "version": "3.3.2",
+            "version": "3.4.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/composer/pcre.git",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e"
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/composer/pcre/zipball/b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
-                "reference": "b2bed4734f0cc156ee1fe9c0da2550420d99a21e",
+                "url": "https://api.github.com/repos/composer/pcre/zipball/d5a341b3fb61f3001970940afb1d332968a183ed",
+                "reference": "d5a341b3fb61f3001970940afb1d332968a183ed",
                 "shasum": ""
             },
             "require": {
                 "php": "^7.4 || ^8.0"
             },
             "conflict": {
-                "phpstan/phpstan": "<1.11.10"
+                "phpstan/phpstan": "<2.2.2"
             },
             "require-dev": {
-                "phpstan/phpstan": "^1.12 || ^2",
-                "phpstan/phpstan-strict-rules": "^1 || ^2",
-                "phpunit/phpunit": "^8 || ^9"
+                "phpstan/phpstan": "^2",
+                "phpstan/phpstan-deprecation-rules": "^2",
+                "phpstan/phpstan-strict-rules": "^2",
+                "phpunit/phpunit": "^9"
             },
             "type": "library",
             "extra": {
@@ -7641,7 +7740,7 @@
             ],
             "support": {
                 "issues": "https://github.com/composer/pcre/issues",
-                "source": "https://github.com/composer/pcre/tree/3.3.2"
+                "source": "https://github.com/composer/pcre/tree/3.4.0"
             },
             "funding": [
                 {
@@ -7651,13 +7750,9 @@
                 {
                     "url": "https://github.com/composer",
                     "type": "github"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
-                    "type": "tidelift"
                 }
             ],
-            "time": "2024-11-12T16:29:46+00:00"
+            "time": "2026-06-07T11:47:49+00:00"
         },
         {
             "name": "composer/semver",
@@ -7735,6 +7830,120 @@
                 }
             ],
             "time": "2025-08-20T19:15:30+00:00"
+        },
+        {
+            "name": "composer/xdebug-handler",
+            "version": "3.0.5",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/composer/xdebug-handler.git",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/composer/xdebug-handler/zipball/6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "reference": "6c1925561632e83d60a44492e0b344cf48ab85ef",
+                "shasum": ""
+            },
+            "require": {
+                "composer/pcre": "^1 || ^2 || ^3",
+                "php": "^7.2.5 || ^8.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "require-dev": {
+                "phpstan/phpstan": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.1",
+                "phpunit/phpunit": "^8.5 || ^9.6 || ^10.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Composer\\XdebugHandler\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "John Stevenson",
+                    "email": "john-stevenson@blueyonder.co.uk"
+                }
+            ],
+            "description": "Restarts a process without Xdebug.",
+            "keywords": [
+                "Xdebug",
+                "performance"
+            ],
+            "support": {
+                "irc": "ircs://irc.libera.chat:6697/composer",
+                "issues": "https://github.com/composer/xdebug-handler/issues",
+                "source": "https://github.com/composer/xdebug-handler/tree/3.0.5"
+            },
+            "funding": [
+                {
+                    "url": "https://packagist.com",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/composer",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/composer/composer",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2024-05-06T16:37:16+00:00"
+        },
+        {
+            "name": "doctrine/deprecations",
+            "version": "1.1.6",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/doctrine/deprecations.git",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/doctrine/deprecations/zipball/d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "reference": "d4fe3e6fd9bb9e72557a19674f44d8ac7db4c6ca",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<=7.5 || >=14"
+            },
+            "require-dev": {
+                "doctrine/coding-standard": "^9 || ^12 || ^14",
+                "phpstan/phpstan": "1.4.10 || 2.1.30",
+                "phpstan/phpstan-phpunit": "^1.0 || ^2",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.6 || ^10.5 || ^11.5 || ^12.4 || ^13.0",
+                "psr/log": "^1 || ^2 || ^3"
+            },
+            "suggest": {
+                "psr/log": "Allows logging deprecations via PSR-3 logger implementation"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Doctrine\\Deprecations\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "A small layer on top of trigger_error(E_USER_DEPRECATED) or PSR-3 logging with options to disable all deprecations or selectively for packages.",
+            "homepage": "https://www.doctrine-project.org/",
+            "support": {
+                "issues": "https://github.com/doctrine/deprecations/issues",
+                "source": "https://github.com/doctrine/deprecations/tree/1.1.6"
+            },
+            "time": "2026-02-07T07:09:04+00:00"
         },
         {
             "name": "dragon-code/contracts",
@@ -8028,6 +8237,67 @@
             "time": "2024-11-21T13:46:39+00:00"
         },
         {
+            "name": "fidry/cpu-core-counter",
+            "version": "1.3.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theofidry/cpu-core-counter.git",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theofidry/cpu-core-counter/zipball/db9508f7b1474469d9d3c53b86f817e344732678",
+                "reference": "db9508f7b1474469d9d3c53b86f817e344732678",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "require-dev": {
+                "fidry/makefile": "^0.2.0",
+                "fidry/php-cs-fixer-config": "^1.1.2",
+                "phpstan/extension-installer": "^1.2.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-deprecation-rules": "^2.0.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^8.5.31 || ^9.5.26",
+                "webmozarts/strict-phpunit": "^7.5"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Fidry\\CpuCoreCounter\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Théo FIDRY",
+                    "email": "theo.fidry@gmail.com"
+                }
+            ],
+            "description": "Tiny utility to get the number of CPU cores.",
+            "keywords": [
+                "CPU",
+                "core"
+            ],
+            "support": {
+                "issues": "https://github.com/theofidry/cpu-core-counter/issues",
+                "source": "https://github.com/theofidry/cpu-core-counter/tree/1.3.0"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/theofidry",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-14T07:29:31+00:00"
+        },
+        {
             "name": "filp/whoops",
             "version": "2.18.4",
             "source": {
@@ -8148,6 +8418,66 @@
                 "source": "https://github.com/hamcrest/hamcrest-php/tree/v2.1.1"
             },
             "time": "2025-04-30T06:54:44+00:00"
+        },
+        {
+            "name": "jean85/pretty-package-versions",
+            "version": "2.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/Jean85/pretty-package-versions.git",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/Jean85/pretty-package-versions/zipball/4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "reference": "4d7aa5dab42e2a76d99559706022885de0e18e1a",
+                "shasum": ""
+            },
+            "require": {
+                "composer-runtime-api": "^2.1.0",
+                "php": "^7.4|^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^3.2",
+                "jean85/composer-provided-replaced-stub-package": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpunit/phpunit": "^7.5|^8.5|^9.6",
+                "rector/rector": "^2.0",
+                "vimeo/psalm": "^4.3 || ^5.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Jean85\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Alessandro Lai",
+                    "email": "alessandro.lai85@gmail.com"
+                }
+            ],
+            "description": "A library to get pretty versions strings of installed dependencies",
+            "keywords": [
+                "composer",
+                "package",
+                "release",
+                "versions"
+            ],
+            "support": {
+                "issues": "https://github.com/Jean85/pretty-package-versions/issues",
+                "source": "https://github.com/Jean85/pretty-package-versions/tree/2.1.1"
+            },
+            "time": "2025-03-19T14:43:43+00:00"
         },
         {
             "name": "laravel-lang/actions",
@@ -9867,23 +10197,23 @@
         },
         {
             "name": "nunomaduro/collision",
-            "version": "v8.9.1",
+            "version": "v8.9.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/collision.git",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935"
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
-                "reference": "a1ed3fa530fd60bc515f9303e8520fcb7d4bd935",
+                "url": "https://api.github.com/repos/nunomaduro/collision/zipball/716af8f95a470e9094cfca09ed897b023be191a5",
+                "reference": "716af8f95a470e9094cfca09ed897b023be191a5",
                 "shasum": ""
             },
             "require": {
                 "filp/whoops": "^2.18.4",
                 "nunomaduro/termwind": "^2.4.0",
                 "php": "^8.2.0",
-                "symfony/console": "^7.4.4 || ^8.0.4"
+                "symfony/console": "^7.4.8 || ^8.0.8"
             },
             "conflict": {
                 "laravel/framework": "<11.48.0 || >=14.0.0",
@@ -9891,12 +10221,12 @@
             },
             "require-dev": {
                 "brianium/paratest": "^7.8.5",
-                "larastan/larastan": "^3.9.2",
-                "laravel/framework": "^11.48.0 || ^12.52.0",
-                "laravel/pint": "^1.27.1",
-                "orchestra/testbench-core": "^9.12.0 || ^10.9.0",
-                "pestphp/pest": "^3.8.5 || ^4.4.1 || ^5.0.0",
-                "sebastian/environment": "^7.2.1 || ^8.0.3 || ^9.0.0"
+                "larastan/larastan": "^3.9.6",
+                "laravel/framework": "^11.48.0 || ^12.56.0 || ^13.5.0",
+                "laravel/pint": "^1.29.1",
+                "orchestra/testbench-core": "^9.12.0 || ^10.12.1 || ^11.2.1",
+                "pestphp/pest": "^3.8.5 || ^4.4.3 || ^5.0.0",
+                "sebastian/environment": "^7.2.1 || ^8.0.4 || ^9.3.0"
             },
             "type": "library",
             "extra": {
@@ -9959,7 +10289,538 @@
                     "type": "patreon"
                 }
             ],
-            "time": "2026-02-17T17:33:08+00:00"
+            "time": "2026-04-21T14:04:20+00:00"
+        },
+        {
+            "name": "pestphp/pest",
+            "version": "v4.7.4",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest.git",
+                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest/zipball/ee2e97e932d158faceeaa63a4dc17324b15152cb",
+                "reference": "ee2e97e932d158faceeaa63a4dc17324b15152cb",
+                "shasum": ""
+            },
+            "require": {
+                "brianium/paratest": "^7.20.0",
+                "composer/xdebug-handler": "^3.0.5",
+                "nunomaduro/collision": "^8.9.4",
+                "nunomaduro/termwind": "^2.4.0",
+                "pestphp/pest-plugin": "^4.0.0",
+                "pestphp/pest-plugin-arch": "^4.0.2",
+                "pestphp/pest-plugin-mutate": "^4.0.1",
+                "pestphp/pest-plugin-profanity": "^4.2.1",
+                "php": "^8.3.0",
+                "phpunit/phpunit": "^12.5.30",
+                "symfony/process": "^7.4.13|^8.1.0"
+            },
+            "conflict": {
+                "filp/whoops": "<2.18.3",
+                "phpunit/phpunit": ">12.5.30",
+                "sebastian/exporter": "<7.0.0",
+                "webmozart/assert": "<1.11.0"
+            },
+            "require-dev": {
+                "mrpunyapal/peststan": "^0.2.10",
+                "pestphp/pest-dev-tools": "^4.1.0",
+                "pestphp/pest-plugin-browser": "^4.3.1",
+                "pestphp/pest-plugin-type-coverage": "^4.0.4",
+                "psy/psysh": "^0.12.23"
+            },
+            "bin": [
+                "bin/pest"
+            ],
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Mutate\\Plugins\\Mutate",
+                        "Pest\\Plugins\\Configuration",
+                        "Pest\\Plugins\\Bail",
+                        "Pest\\Plugins\\Cache",
+                        "Pest\\Plugins\\Coverage",
+                        "Pest\\Plugins\\Init",
+                        "Pest\\Plugins\\Environment",
+                        "Pest\\Plugins\\Help",
+                        "Pest\\Plugins\\Memory",
+                        "Pest\\Plugins\\Only",
+                        "Pest\\Plugins\\Printer",
+                        "Pest\\Plugins\\ProcessIsolation",
+                        "Pest\\Plugins\\Profile",
+                        "Pest\\Plugins\\Retry",
+                        "Pest\\Plugins\\Snapshot",
+                        "Pest\\Plugins\\Verbose",
+                        "Pest\\Plugins\\Version",
+                        "Pest\\Plugins\\Shard",
+                        "Pest\\Plugins\\Tia",
+                        "Pest\\Plugins\\Parallel"
+                    ]
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Functions.php",
+                    "src/Pest.php"
+                ],
+                "psr-4": {
+                    "Pest\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "The elegant PHP Testing Framework.",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "issues": "https://github.com/pestphp/pest/issues",
+                "source": "https://github.com/pestphp/pest/tree/v4.7.4"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-06-25T19:09:05+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin",
+            "version": "v4.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin.git",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin/zipball/9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "reference": "9d4b93d7f73d3f9c3189bb22c220fef271cdf568",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^2.0.0",
+                "composer-runtime-api": "^2.2.2",
+                "php": "^8.3"
+            },
+            "conflict": {
+                "pestphp/pest": "<4.0.0"
+            },
+            "require-dev": {
+                "composer/composer": "^2.8.10",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "Pest\\Plugin\\Manager"
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Plugin\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest plugin manager",
+            "keywords": [
+                "framework",
+                "manager",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin/tree/v4.0.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2025-08-20T12:35:58+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-arch",
+            "version": "v4.0.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-arch.git",
+                "reference": "3fb0d02a91b9da504b139dc7ab2a31efb7c3215c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-arch/zipball/3fb0d02a91b9da504b139dc7ab2a31efb7c3215c",
+                "reference": "3fb0d02a91b9da504b139dc7ab2a31efb7c3215c",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "ta-tikoma/phpunit-architecture-test": "^0.8.7"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.4.6",
+                "pestphp/pest-dev-tools": "^4.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Arch\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Arch\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Arch plugin for Pest PHP.",
+            "keywords": [
+                "arch",
+                "architecture",
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-arch/tree/v4.0.2"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-04-10T17:20:19+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-laravel",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-laravel.git",
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-laravel/zipball/3057a36669ff11416cc0dc2b521b3aec58c488d0",
+                "reference": "3057a36669ff11416cc0dc2b521b3aec58c488d0",
+                "shasum": ""
+            },
+            "require": {
+                "laravel/framework": "^11.45.2|^12.52.0|^13.0",
+                "pestphp/pest": "^4.4.1",
+                "php": "^8.3.0"
+            },
+            "require-dev": {
+                "laravel/dusk": "^8.3.6",
+                "orchestra/testbench": "^9.13.0|^10.9.0|^11.0",
+                "pestphp/pest-dev-tools": "^4.1.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Laravel\\Plugin"
+                    ]
+                },
+                "laravel": {
+                    "providers": [
+                        "Pest\\Laravel\\PestServiceProvider"
+                    ]
+                }
+            },
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Laravel\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Laravel Plugin",
+            "keywords": [
+                "framework",
+                "laravel",
+                "pest",
+                "php",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-laravel/tree/v4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2026-02-21T00:29:45+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-livewire",
+            "version": "v4.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-livewire.git",
+                "reference": "0b5a137ec6ceadd19dd2c59b9b60039d64f6b4d2"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-livewire/zipball/0b5a137ec6ceadd19dd2c59b9b60039d64f6b4d2",
+                "reference": "0b5a137ec6ceadd19dd2c59b9b60039d64f6b4d2",
+                "shasum": ""
+            },
+            "require": {
+                "livewire/livewire": "^3.7.4|^4.0.1",
+                "pestphp/pest": "^4.3.1",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "orchestra/testbench": "^10.9.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "files": [
+                    "src/Autoload.php"
+                ],
+                "psr-4": {
+                    "Pest\\Livewire\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Livewire Plugin",
+            "keywords": [
+                "framework",
+                "livewire",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-livewire/tree/v4.1.0"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/cgi-bin/webscr?cmd=_s-xclick&hosted_button_id=66BYDWAT92N6L",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/nunomaduro",
+                    "type": "patreon"
+                }
+            ],
+            "time": "2026-01-16T00:56:22+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-mutate",
+            "version": "v4.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-mutate.git",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-mutate/zipball/d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "reference": "d9b32b60b2385e1688a68cc227594738ec26d96c",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^5.6.1",
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3",
+                "psr/simple-cache": "^3.0.0"
+            },
+            "require-dev": {
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0",
+                "pestphp/pest-plugin-type-coverage": "^4.0.0"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Mutate\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                },
+                {
+                    "name": "Sandro Gehri",
+                    "email": "sandrogehri@gmail.com"
+                }
+            ],
+            "description": "Mutates your code to find untested cases",
+            "keywords": [
+                "framework",
+                "mutate",
+                "mutation",
+                "pest",
+                "php",
+                "plugin",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-mutate/tree/v4.0.1"
+            },
+            "funding": [
+                {
+                    "url": "https://www.paypal.com/paypalme/enunomaduro",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/gehrisandro",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/nunomaduro",
+                    "type": "github"
+                }
+            ],
+            "time": "2025-08-21T20:19:25+00:00"
+        },
+        {
+            "name": "pestphp/pest-plugin-profanity",
+            "version": "v4.2.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/pestphp/pest-plugin-profanity.git",
+                "reference": "343cfa6f3564b7e35df0ebb77b7fa97039f72b27"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/pestphp/pest-plugin-profanity/zipball/343cfa6f3564b7e35df0ebb77b7fa97039f72b27",
+                "reference": "343cfa6f3564b7e35df0ebb77b7fa97039f72b27",
+                "shasum": ""
+            },
+            "require": {
+                "pestphp/pest-plugin": "^4.0.0",
+                "php": "^8.3"
+            },
+            "require-dev": {
+                "faissaloux/pest-plugin-inside": "^1.9",
+                "pestphp/pest": "^4.0.0",
+                "pestphp/pest-dev-tools": "^4.0.0"
+            },
+            "type": "library",
+            "extra": {
+                "pest": {
+                    "plugins": [
+                        "Pest\\Profanity\\Plugin"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pest\\Profanity\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "The Pest Profanity Plugin",
+            "keywords": [
+                "framework",
+                "pest",
+                "php",
+                "plugin",
+                "profanity",
+                "test",
+                "testing",
+                "unit"
+            ],
+            "support": {
+                "source": "https://github.com/pestphp/pest-plugin-profanity/tree/v4.2.1"
+            },
+            "time": "2025-12-08T00:13:17+00:00"
         },
         {
             "name": "phar-io/manifest",
@@ -10248,17 +11109,240 @@
             "time": "2026-01-15T14:47:34+00:00"
         },
         {
-            "name": "phpunit/php-code-coverage",
-            "version": "11.0.12",
+            "name": "phpdocumentor/reflection-common",
+            "version": "2.2.0",
             "source": {
                 "type": "git",
-                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56"
+                "url": "https://github.com/phpDocumentor/ReflectionCommon.git",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/2c1ed04922802c15e1de5d7447b4856de949cf56",
-                "reference": "2c1ed04922802c15e1de5d7447b4856de949cf56",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionCommon/zipball/1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "reference": "1d01c49d4ed62f25aa84a747ad35d5a16924662b",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.2 || ^8.0"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "Common reflection classes used by phpdocumentor to reflect the code structure",
+            "homepage": "http://www.phpdoc.org",
+            "keywords": [
+                "FQSEN",
+                "phpDocumentor",
+                "phpdoc",
+                "reflection",
+                "static analysis"
+            ],
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionCommon/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionCommon/tree/2.x"
+            },
+            "time": "2020-06-27T09:03:43+00:00"
+        },
+        {
+            "name": "phpdocumentor/reflection-docblock",
+            "version": "6.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/ReflectionDocBlock.git",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/ReflectionDocBlock/zipball/7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "reference": "7bae67520aa9f5ecc506d646810bd40d9da54582",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.1",
+                "ext-filter": "*",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.2",
+                "phpdocumentor/type-resolver": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0",
+                "webmozart/assert": "^1.9.1 || ^2"
+            },
+            "require-dev": {
+                "mockery/mockery": "~1.3.5 || ~1.6.0",
+                "phpstan/extension-installer": "^1.1",
+                "phpstan/phpstan": "^1.8",
+                "phpstan/phpstan-mockery": "^1.1",
+                "phpstan/phpstan-webmozart-assert": "^1.2",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^5.26",
+                "shipmonk/dead-code-detector": "^0.5.1"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "5.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                },
+                {
+                    "name": "Jaap van Otterdijk",
+                    "email": "opensource@ijaap.nl"
+                }
+            ],
+            "description": "With this component, a library can provide support for annotations via DocBlocks or otherwise retrieve information that is embedded in a DocBlock.",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/ReflectionDocBlock/issues",
+                "source": "https://github.com/phpDocumentor/ReflectionDocBlock/tree/6.0.3"
+            },
+            "time": "2026-03-18T20:49:53+00:00"
+        },
+        {
+            "name": "phpdocumentor/type-resolver",
+            "version": "2.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpDocumentor/TypeResolver.git",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpDocumentor/TypeResolver/zipball/327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "reference": "327a05bbee54120d4786a0dc67aad30226ad4cf9",
+                "shasum": ""
+            },
+            "require": {
+                "doctrine/deprecations": "^1.0",
+                "php": "^7.4 || ^8.0",
+                "phpdocumentor/reflection-common": "^2.0",
+                "phpstan/phpdoc-parser": "^2.0"
+            },
+            "require-dev": {
+                "ext-tokenizer": "*",
+                "phpbench/phpbench": "^1.2",
+                "phpstan/extension-installer": "^1.4",
+                "phpstan/phpstan": "^2.1",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpunit/phpunit": "^9.5",
+                "psalm/phar": "^4"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-1.x": "1.x-dev",
+                    "dev-2.x": "2.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "phpDocumentor\\Reflection\\": "src"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Mike van Riel",
+                    "email": "me@mikevanriel.com"
+                }
+            ],
+            "description": "A PSR-5 based resolver of Class names, Types and Structural Element Names",
+            "support": {
+                "issues": "https://github.com/phpDocumentor/TypeResolver/issues",
+                "source": "https://github.com/phpDocumentor/TypeResolver/tree/2.0.0"
+            },
+            "time": "2026-01-06T21:53:42+00:00"
+        },
+        {
+            "name": "phpstan/phpdoc-parser",
+            "version": "2.3.2",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpdoc-parser.git",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpdoc-parser/zipball/a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "reference": "a004701b11273a26cd7955a61d67a7f1e525a45a",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^2.0",
+                "nikic/php-parser": "^5.3.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/extension-installer": "^1.0",
+                "phpstan/phpstan": "^2.0",
+                "phpstan/phpstan-phpunit": "^2.0",
+                "phpstan/phpstan-strict-rules": "^2.0",
+                "phpunit/phpunit": "^9.6",
+                "symfony/process": "^5.2"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\PhpDocParser\\": [
+                        "src/"
+                    ]
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPDoc parser with support for nullable, intersection and generic types",
+            "support": {
+                "issues": "https://github.com/phpstan/phpdoc-parser/issues",
+                "source": "https://github.com/phpstan/phpdoc-parser/tree/2.3.2"
+            },
+            "time": "2026-01-25T14:56:51+00:00"
+        },
+        {
+            "name": "phpunit/php-code-coverage",
+            "version": "12.5.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
+                "reference": "186dab580576598076de6818596d12b61801880e"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/186dab580576598076de6818596d12b61801880e",
+                "reference": "186dab580576598076de6818596d12b61801880e",
                 "shasum": ""
             },
             "require": {
@@ -10266,18 +11350,16 @@
                 "ext-libxml": "*",
                 "ext-xmlwriter": "*",
                 "nikic/php-parser": "^5.7.0",
-                "php": ">=8.2",
-                "phpunit/php-file-iterator": "^5.1.0",
-                "phpunit/php-text-template": "^4.0.1",
-                "sebastian/code-unit-reverse-lookup": "^4.0.1",
-                "sebastian/complexity": "^4.0.1",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/lines-of-code": "^3.0.1",
-                "sebastian/version": "^5.0.2",
-                "theseer/tokenizer": "^1.3.1"
+                "php": ">=8.3",
+                "phpunit/php-text-template": "^5.0",
+                "sebastian/complexity": "^5.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/lines-of-code": "^4.0.1",
+                "sebastian/version": "^6.0",
+                "theseer/tokenizer": "^2.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.5.46"
+                "phpunit/phpunit": "^12.5.28"
             },
             "suggest": {
                 "ext-pcov": "PHP extension that provides line coverage",
@@ -10286,7 +11368,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.0.x-dev"
+                    "dev-main": "12.5.x-dev"
                 }
             },
             "autoload": {
@@ -10315,7 +11397,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
                 "security": "https://github.com/sebastianbergmann/php-code-coverage/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/11.0.12"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/12.5.7"
             },
             "funding": [
                 {
@@ -10335,32 +11417,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-12-24T07:01:01+00:00"
+            "time": "2026-06-01T13:24:19+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
-            "version": "5.1.1",
+            "version": "6.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-file-iterator.git",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903"
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/2f3a64888c814fc235386b7387dd5b5ed92ad903",
-                "reference": "2f3a64888c814fc235386b7387dd5b5ed92ad903",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-file-iterator/zipball/3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
+                "reference": "3d1cd096ef6bea4bf2762ba586e35dbd317cbfd5",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -10388,7 +11470,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-file-iterator/issues",
                 "security": "https://github.com/sebastianbergmann/php-file-iterator/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/5.1.1"
+                "source": "https://github.com/sebastianbergmann/php-file-iterator/tree/6.0.1"
             },
             "funding": [
                 {
@@ -10408,28 +11490,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-02-02T13:52:54+00:00"
+            "time": "2026-02-02T14:04:18+00:00"
         },
         {
             "name": "phpunit/php-invoker",
-            "version": "5.0.1",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-invoker.git",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2"
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/c1ca3814734c07492b3d4c5f794f4b0995333da2",
-                "reference": "c1ca3814734c07492b3d4c5f794f4b0995333da2",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-invoker/zipball/12b54e689b07a25a9b41e57736dfab6ec9ae5406",
+                "reference": "12b54e689b07a25a9b41e57736dfab6ec9ae5406",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
                 "ext-pcntl": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "suggest": {
                 "ext-pcntl": "*"
@@ -10437,7 +11519,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -10464,7 +11546,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-invoker/issues",
                 "security": "https://github.com/sebastianbergmann/php-invoker/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-invoker/tree/5.0.1"
+                "source": "https://github.com/sebastianbergmann/php-invoker/tree/6.0.0"
             },
             "funding": [
                 {
@@ -10472,32 +11554,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:07:44+00:00"
+            "time": "2025-02-07T04:58:58+00:00"
         },
         {
             "name": "phpunit/php-text-template",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-text-template.git",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964"
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
-                "reference": "3e0404dc6b300e6bf56415467ebcb3fe4f33e964",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-text-template/zipball/e1367a453f0eda562eedb4f659e13aa900d66c53",
+                "reference": "e1367a453f0eda562eedb4f659e13aa900d66c53",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -10524,7 +11606,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-text-template/issues",
                 "security": "https://github.com/sebastianbergmann/php-text-template/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-text-template/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/php-text-template/tree/5.0.0"
             },
             "funding": [
                 {
@@ -10532,32 +11614,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:08:43+00:00"
+            "time": "2025-02-07T04:59:16+00:00"
         },
         {
             "name": "phpunit/php-timer",
-            "version": "7.0.1",
+            "version": "8.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-timer.git",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3"
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
-                "reference": "3b415def83fbcb41f991d9ebf16ae4ad8b7837b3",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-timer/zipball/f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
+                "reference": "f258ce36aa457f3aa3339f9ed4c81fc66dc8c2cc",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -10584,7 +11666,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-timer/issues",
                 "security": "https://github.com/sebastianbergmann/php-timer/security/policy",
-                "source": "https://github.com/sebastianbergmann/php-timer/tree/7.0.1"
+                "source": "https://github.com/sebastianbergmann/php-timer/tree/8.0.0"
             },
             "funding": [
                 {
@@ -10592,20 +11674,20 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:09:35+00:00"
+            "time": "2025-02-07T04:59:38+00:00"
         },
         {
             "name": "phpunit/phpunit",
-            "version": "11.5.55",
+            "version": "12.5.30",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00"
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/adc7262fccc12de2b30f12a8aa0b33775d814f00",
-                "reference": "adc7262fccc12de2b30f12a8aa0b33775d814f00",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/900400a5b616d6fb306f9549f6da33ba615d3fbb",
+                "reference": "900400a5b616d6fb306f9549f6da33ba615d3fbb",
                 "shasum": ""
             },
             "require": {
@@ -10618,27 +11700,23 @@
                 "myclabs/deep-copy": "^1.13.4",
                 "phar-io/manifest": "^2.0.4",
                 "phar-io/version": "^3.2.1",
-                "php": ">=8.2",
-                "phpunit/php-code-coverage": "^11.0.12",
-                "phpunit/php-file-iterator": "^5.1.1",
-                "phpunit/php-invoker": "^5.0.1",
-                "phpunit/php-text-template": "^4.0.1",
-                "phpunit/php-timer": "^7.0.1",
-                "sebastian/cli-parser": "^3.0.2",
-                "sebastian/code-unit": "^3.0.3",
-                "sebastian/comparator": "^6.3.3",
-                "sebastian/diff": "^6.0.2",
-                "sebastian/environment": "^7.2.1",
-                "sebastian/exporter": "^6.3.2",
-                "sebastian/global-state": "^7.0.2",
-                "sebastian/object-enumerator": "^6.0.1",
-                "sebastian/recursion-context": "^6.0.3",
-                "sebastian/type": "^5.1.3",
-                "sebastian/version": "^5.0.2",
+                "php": ">=8.3",
+                "phpunit/php-code-coverage": "^12.5.7",
+                "phpunit/php-file-iterator": "^6.0.1",
+                "phpunit/php-invoker": "^6.0.0",
+                "phpunit/php-text-template": "^5.0.0",
+                "phpunit/php-timer": "^8.0.0",
+                "sebastian/cli-parser": "^4.2.1",
+                "sebastian/comparator": "^7.1.8",
+                "sebastian/diff": "^7.0.0",
+                "sebastian/environment": "^8.1.2",
+                "sebastian/exporter": "^7.0.3",
+                "sebastian/global-state": "^8.0.3",
+                "sebastian/object-enumerator": "^7.0.0",
+                "sebastian/recursion-context": "^7.0.1",
+                "sebastian/type": "^6.0.4",
+                "sebastian/version": "^6.0.0",
                 "staabm/side-effects-detector": "^1.0.5"
-            },
-            "suggest": {
-                "ext-soap": "To be able to generate mocks based on WSDL files"
             },
             "bin": [
                 "phpunit"
@@ -10646,7 +11724,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "11.5-dev"
+                    "dev-main": "12.5-dev"
                 }
             },
             "autoload": {
@@ -10678,56 +11756,40 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
                 "security": "https://github.com/sebastianbergmann/phpunit/security/policy",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/11.5.55"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/12.5.30"
             },
             "funding": [
                 {
-                    "url": "https://phpunit.de/sponsors.html",
-                    "type": "custom"
-                },
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                },
-                {
-                    "url": "https://liberapay.com/sebastianbergmann",
-                    "type": "liberapay"
-                },
-                {
-                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
-                    "type": "thanks_dev"
-                },
-                {
-                    "url": "https://tidelift.com/funding/github/packagist/phpunit/phpunit",
-                    "type": "tidelift"
+                    "url": "https://phpunit.de/sponsoring.html",
+                    "type": "other"
                 }
             ],
-            "time": "2026-02-18T12:37:06+00:00"
+            "time": "2026-06-15T13:12:30+00:00"
         },
         {
             "name": "sebastian/cli-parser",
-            "version": "3.0.2",
+            "version": "4.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/cli-parser.git",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180"
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/15c5dd40dc4f38794d383bb95465193f5e0ae180",
-                "reference": "15c5dd40dc4f38794d383bb95465193f5e0ae180",
+                "url": "https://api.github.com/repos/sebastianbergmann/cli-parser/zipball/7d05781b13f7dec9043a629a21d086ed74582a15",
+                "reference": "7d05781b13f7dec9043a629a21d086ed74582a15",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.2-dev"
                 }
             },
             "autoload": {
@@ -10751,152 +11813,51 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/cli-parser/issues",
                 "security": "https://github.com/sebastianbergmann/cli-parser/security/policy",
-                "source": "https://github.com/sebastianbergmann/cli-parser/tree/3.0.2"
+                "source": "https://github.com/sebastianbergmann/cli-parser/tree/4.2.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:41:36+00:00"
-        },
-        {
-            "name": "sebastian/code-unit",
-            "version": "3.0.3",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit.git",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit/zipball/54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "reference": "54391c61e4af8078e5b276ab082b6d3c54c9ad64",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.5"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "3.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de",
-                    "role": "lead"
-                }
-            ],
-            "description": "Collection of value objects that represent the PHP code units",
-            "homepage": "https://github.com/sebastianbergmann/code-unit",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit/tree/3.0.3"
-            },
-            "funding": [
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
                 {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2025-03-19T07:56:08+00:00"
-        },
-        {
-            "name": "sebastian/code-unit-reverse-lookup",
-            "version": "4.0.1",
-            "source": {
-                "type": "git",
-                "url": "https://github.com/sebastianbergmann/code-unit-reverse-lookup.git",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e"
-            },
-            "dist": {
-                "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/code-unit-reverse-lookup/zipball/183a9b2632194febd219bb9246eee421dad8d45e",
-                "reference": "183a9b2632194febd219bb9246eee421dad8d45e",
-                "shasum": ""
-            },
-            "require": {
-                "php": ">=8.2"
-            },
-            "require-dev": {
-                "phpunit/phpunit": "^11.0"
-            },
-            "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-main": "4.0-dev"
-                }
-            },
-            "autoload": {
-                "classmap": [
-                    "src/"
-                ]
-            },
-            "notification-url": "https://packagist.org/downloads/",
-            "license": [
-                "BSD-3-Clause"
-            ],
-            "authors": [
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
                 {
-                    "name": "Sebastian Bergmann",
-                    "email": "sebastian@phpunit.de"
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/cli-parser",
+                    "type": "tidelift"
                 }
             ],
-            "description": "Looks up which function or method a line of code belongs to",
-            "homepage": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/",
-            "support": {
-                "issues": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/issues",
-                "security": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/security/policy",
-                "source": "https://github.com/sebastianbergmann/code-unit-reverse-lookup/tree/4.0.1"
-            },
-            "funding": [
-                {
-                    "url": "https://github.com/sebastianbergmann",
-                    "type": "github"
-                }
-            ],
-            "time": "2024-07-03T04:45:54+00:00"
+            "time": "2026-05-17T05:29:34+00:00"
         },
         {
             "name": "sebastian/comparator",
-            "version": "6.3.3",
+            "version": "7.1.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/comparator.git",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9"
+                "reference": "7c65c1e79836812819705b473a90c12399542485"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
-                "reference": "2c95e1e86cb8dd41beb8d502057d1081ccc8eca9",
+                "url": "https://api.github.com/repos/sebastianbergmann/comparator/zipball/7c65c1e79836812819705b473a90c12399542485",
+                "reference": "7c65c1e79836812819705b473a90c12399542485",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/diff": "^6.0",
-                "sebastian/exporter": "^6.0"
+                "php": ">=8.3",
+                "sebastian/diff": "^7.0",
+                "sebastian/exporter": "^7.0.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.4"
+                "phpunit/phpunit": "^12.5.25"
             },
             "suggest": {
                 "ext-bcmath": "For comparing BcMath\\Number objects"
@@ -10904,7 +11865,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.1-dev"
                 }
             },
             "autoload": {
@@ -10944,7 +11905,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/comparator/issues",
                 "security": "https://github.com/sebastianbergmann/comparator/security/policy",
-                "source": "https://github.com/sebastianbergmann/comparator/tree/6.3.3"
+                "source": "https://github.com/sebastianbergmann/comparator/tree/7.1.8"
             },
             "funding": [
                 {
@@ -10964,33 +11925,33 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-01-24T09:26:40+00:00"
+            "time": "2026-05-21T04:45:25+00:00"
         },
         {
             "name": "sebastian/complexity",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/complexity.git",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0"
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/ee41d384ab1906c68852636b6de493846e13e5a0",
-                "reference": "ee41d384ab1906c68852636b6de493846e13e5a0",
+                "url": "https://api.github.com/repos/sebastianbergmann/complexity/zipball/bad4316aba5303d0221f43f8cee37eb58d384bbb",
+                "reference": "bad4316aba5303d0221f43f8cee37eb58d384bbb",
                 "shasum": ""
             },
             "require": {
                 "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11014,7 +11975,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/complexity/issues",
                 "security": "https://github.com/sebastianbergmann/complexity/security/policy",
-                "source": "https://github.com/sebastianbergmann/complexity/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/complexity/tree/5.0.0"
             },
             "funding": [
                 {
@@ -11022,33 +11983,33 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:49:50+00:00"
+            "time": "2025-02-07T04:55:25+00:00"
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/7ab1ea946c012266ca32390913653d844ecd085f",
+                "reference": "7ab1ea946c012266ca32390913653d844ecd085f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^12.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11081,7 +12042,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/7.0.0"
             },
             "funding": [
                 {
@@ -11089,27 +12050,27 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2025-02-07T04:55:46+00:00"
         },
         {
             "name": "sebastian/environment",
-            "version": "7.2.1",
+            "version": "8.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/environment.git",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4"
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/a5c75038693ad2e8d4b6c15ba2403532647830c4",
-                "reference": "a5c75038693ad2e8d4b6c15ba2403532647830c4",
+                "url": "https://api.github.com/repos/sebastianbergmann/environment/zipball/9d32c685773823b1983e256ae4ecd48a10d6e439",
+                "reference": "9d32c685773823b1983e256ae4ecd48a10d6e439",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.26"
             },
             "suggest": {
                 "ext-posix": "*"
@@ -11117,7 +12078,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.2-dev"
+                    "dev-main": "8.1-dev"
                 }
             },
             "autoload": {
@@ -11145,7 +12106,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/environment/issues",
                 "security": "https://github.com/sebastianbergmann/environment/security/policy",
-                "source": "https://github.com/sebastianbergmann/environment/tree/7.2.1"
+                "source": "https://github.com/sebastianbergmann/environment/tree/8.1.2"
             },
             "funding": [
                 {
@@ -11165,34 +12126,34 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-05-21T11:55:47+00:00"
+            "time": "2026-05-25T13:40:20+00:00"
         },
         {
             "name": "sebastian/exporter",
-            "version": "6.3.2",
+            "version": "7.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/exporter.git",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74"
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/70a298763b40b213ec087c51c739efcaa90bcd74",
-                "reference": "70a298763b40b213ec087c51c739efcaa90bcd74",
+                "url": "https://api.github.com/repos/sebastianbergmann/exporter/zipball/c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
+                "reference": "c5e21b5de653ce0a769fb36f5cdfcb5e7a32cf23",
                 "shasum": ""
             },
             "require": {
                 "ext-mbstring": "*",
-                "php": ">=8.2",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.3-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11235,7 +12196,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/exporter/issues",
                 "security": "https://github.com/sebastianbergmann/exporter/security/policy",
-                "source": "https://github.com/sebastianbergmann/exporter/tree/6.3.2"
+                "source": "https://github.com/sebastianbergmann/exporter/tree/7.0.3"
             },
             "funding": [
                 {
@@ -11255,35 +12216,35 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-09-24T06:12:51+00:00"
+            "time": "2026-05-20T04:37:17+00:00"
         },
         {
             "name": "sebastian/global-state",
-            "version": "7.0.2",
+            "version": "8.0.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/global-state.git",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7"
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/3be331570a721f9a4b5917f4209773de17f747d7",
-                "reference": "3be331570a721f9a4b5917f4209773de17f747d7",
+                "url": "https://api.github.com/repos/sebastianbergmann/global-state/zipball/b164d3274d6537ab462591c5755f76a8f5b1aae9",
+                "reference": "b164d3274d6537ab462591c5755f76a8f5b1aae9",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0.1"
             },
             "require-dev": {
                 "ext-dom": "*",
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.28"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "7.0-dev"
+                    "dev-main": "8.0-dev"
                 }
             },
             "autoload": {
@@ -11309,41 +12270,53 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/global-state/issues",
                 "security": "https://github.com/sebastianbergmann/global-state/security/policy",
-                "source": "https://github.com/sebastianbergmann/global-state/tree/7.0.2"
+                "source": "https://github.com/sebastianbergmann/global-state/tree/8.0.3"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/global-state",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:57:36+00:00"
+            "time": "2026-06-01T15:10:33+00:00"
         },
         {
             "name": "sebastian/lines-of-code",
-            "version": "3.0.1",
+            "version": "4.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/lines-of-code.git",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a"
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d36ad0d782e5756913e42ad87cb2890f4ffe467a",
-                "reference": "d36ad0d782e5756913e42ad87cb2890f4ffe467a",
+                "url": "https://api.github.com/repos/sebastianbergmann/lines-of-code/zipball/d543b8ef219dcd8da262cbb958639a96bedba10e",
+                "reference": "d543b8ef219dcd8da262cbb958639a96bedba10e",
                 "shasum": ""
             },
             "require": {
-                "nikic/php-parser": "^5.0",
-                "php": ">=8.2"
+                "nikic/php-parser": "^5.7.0",
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.0-dev"
+                    "dev-main": "4.0-dev"
                 }
             },
             "autoload": {
@@ -11367,42 +12340,54 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/lines-of-code/issues",
                 "security": "https://github.com/sebastianbergmann/lines-of-code/security/policy",
-                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/3.0.1"
+                "source": "https://github.com/sebastianbergmann/lines-of-code/tree/4.0.1"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/lines-of-code",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:58:38+00:00"
+            "time": "2026-05-19T16:22:07+00:00"
         },
         {
             "name": "sebastian/object-enumerator",
-            "version": "6.0.1",
+            "version": "7.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-enumerator.git",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa"
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/f5b498e631a74204185071eb41f33f38d64608aa",
-                "reference": "f5b498e631a74204185071eb41f33f38d64608aa",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-enumerator/zipball/1effe8e9b8e068e9ae228e542d5d11b5d16db894",
+                "reference": "1effe8e9b8e068e9ae228e542d5d11b5d16db894",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "sebastian/object-reflector": "^4.0",
-                "sebastian/recursion-context": "^6.0"
+                "php": ">=8.3",
+                "sebastian/object-reflector": "^5.0",
+                "sebastian/recursion-context": "^7.0"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11425,7 +12410,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-enumerator/issues",
                 "security": "https://github.com/sebastianbergmann/object-enumerator/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/6.0.1"
+                "source": "https://github.com/sebastianbergmann/object-enumerator/tree/7.0.0"
             },
             "funding": [
                 {
@@ -11433,32 +12418,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:00:13+00:00"
+            "time": "2025-02-07T04:57:48+00:00"
         },
         {
             "name": "sebastian/object-reflector",
-            "version": "4.0.1",
+            "version": "5.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/object-reflector.git",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9"
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/6e1a43b411b2ad34146dee7524cb13a068bb35f9",
-                "reference": "6e1a43b411b2ad34146dee7524cb13a068bb35f9",
+                "url": "https://api.github.com/repos/sebastianbergmann/object-reflector/zipball/4bfa827c969c98be1e527abd576533293c634f6a",
+                "reference": "4bfa827c969c98be1e527abd576533293c634f6a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "4.0-dev"
+                    "dev-main": "5.0-dev"
                 }
             },
             "autoload": {
@@ -11481,7 +12466,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/object-reflector/issues",
                 "security": "https://github.com/sebastianbergmann/object-reflector/security/policy",
-                "source": "https://github.com/sebastianbergmann/object-reflector/tree/4.0.1"
+                "source": "https://github.com/sebastianbergmann/object-reflector/tree/5.0.0"
             },
             "funding": [
                 {
@@ -11489,32 +12474,32 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-07-03T05:01:32+00:00"
+            "time": "2025-02-07T04:58:17+00:00"
         },
         {
             "name": "sebastian/recursion-context",
-            "version": "6.0.3",
+            "version": "7.0.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/recursion-context.git",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc"
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/f6458abbf32a6c8174f8f26261475dc133b3d9dc",
-                "reference": "f6458abbf32a6c8174f8f26261475dc133b3d9dc",
+                "url": "https://api.github.com/repos/sebastianbergmann/recursion-context/zipball/0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
+                "reference": "0b01998a7d5b1f122911a66bebcb8d46f0c82d8c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.0"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "7.0-dev"
                 }
             },
             "autoload": {
@@ -11545,7 +12530,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/recursion-context/issues",
                 "security": "https://github.com/sebastianbergmann/recursion-context/security/policy",
-                "source": "https://github.com/sebastianbergmann/recursion-context/tree/6.0.3"
+                "source": "https://github.com/sebastianbergmann/recursion-context/tree/7.0.1"
             },
             "funding": [
                 {
@@ -11565,32 +12550,32 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-13T04:42:22+00:00"
+            "time": "2025-08-13T04:44:59+00:00"
         },
         {
             "name": "sebastian/type",
-            "version": "5.1.3",
+            "version": "6.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/type.git",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449"
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
-                "reference": "f77d2d4e78738c98d9a68d2596fe5e8fa380f449",
+                "url": "https://api.github.com/repos/sebastianbergmann/type/zipball/82ff822c2edc46724be9f7411d3163021f602773",
+                "reference": "82ff822c2edc46724be9f7411d3163021f602773",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.3"
+                "phpunit/phpunit": "^12.5.25"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.1-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11614,7 +12599,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/type/issues",
                 "security": "https://github.com/sebastianbergmann/type/security/policy",
-                "source": "https://github.com/sebastianbergmann/type/tree/5.1.3"
+                "source": "https://github.com/sebastianbergmann/type/tree/6.0.4"
             },
             "funding": [
                 {
@@ -11634,29 +12619,29 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2025-08-09T06:55:48+00:00"
+            "time": "2026-05-20T06:45:45+00:00"
         },
         {
             "name": "sebastian/version",
-            "version": "5.0.2",
+            "version": "6.0.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/version.git",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874"
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/c687e3387b99f5b03b6caa64c74b63e2936ff874",
-                "reference": "c687e3387b99f5b03b6caa64c74b63e2936ff874",
+                "url": "https://api.github.com/repos/sebastianbergmann/version/zipball/3e6ccf7657d4f0a59200564b08cead899313b53c",
+                "reference": "3e6ccf7657d4f0a59200564b08cead899313b53c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.3"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "5.0-dev"
+                    "dev-main": "6.0-dev"
                 }
             },
             "autoload": {
@@ -11680,7 +12665,7 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/version/issues",
                 "security": "https://github.com/sebastianbergmann/version/security/policy",
-                "source": "https://github.com/sebastianbergmann/version/tree/5.0.2"
+                "source": "https://github.com/sebastianbergmann/version/tree/6.0.0"
             },
             "funding": [
                 {
@@ -11688,7 +12673,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2024-10-09T05:16:32+00:00"
+            "time": "2025-02-07T05:00:38+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -11744,16 +12729,16 @@
         },
         {
             "name": "symfony/polyfill-php81",
-            "version": "v1.33.0",
+            "version": "v1.38.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/polyfill-php81.git",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c"
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
-                "reference": "4a4cfc2d253c21a5ad0e53071df248ed48c6ce5c",
+                "url": "https://api.github.com/repos/symfony/polyfill-php81/zipball/6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
+                "reference": "6bfb9c766cacffbc8e118cb87217d08ed84e5cd7",
                 "shasum": ""
             },
             "require": {
@@ -11800,7 +12785,7 @@
                 "shim"
             ],
             "support": {
-                "source": "https://github.com/symfony/polyfill-php81/tree/v1.33.0"
+                "source": "https://github.com/symfony/polyfill-php81/tree/v1.38.1"
             },
             "funding": [
                 {
@@ -11820,7 +12805,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2024-09-09T11:45:10+00:00"
+            "time": "2026-05-26T12:45:58+00:00"
         },
         {
             "name": "symfony/yaml",
@@ -11899,24 +12884,83 @@
             "time": "2026-02-09T09:33:46+00:00"
         },
         {
-            "name": "theseer/tokenizer",
-            "version": "1.3.1",
+            "name": "ta-tikoma/phpunit-architecture-test",
+            "version": "0.8.7",
             "source": {
                 "type": "git",
-                "url": "https://github.com/theseer/tokenizer.git",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c"
+                "url": "https://github.com/ta-tikoma/phpunit-architecture-test.git",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/b7489ce515e168639d17feec34b8847c326b0b3c",
-                "reference": "b7489ce515e168639d17feec34b8847c326b0b3c",
+                "url": "https://api.github.com/repos/ta-tikoma/phpunit-architecture-test/zipball/1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "reference": "1248f3f506ca9641d4f68cebcd538fa489754db8",
+                "shasum": ""
+            },
+            "require": {
+                "nikic/php-parser": "^4.18.0 || ^5.0.0",
+                "php": "^8.1.0",
+                "phpdocumentor/reflection-docblock": "^5.3.0 || ^6.0.0",
+                "phpunit/phpunit": "^10.5.5 || ^11.0.0 || ^12.0.0 || ^13.0.0",
+                "symfony/finder": "^6.4.0 || ^7.0.0 || ^8.0.0"
+            },
+            "require-dev": {
+                "laravel/pint": "^1.13.7",
+                "phpstan/phpstan": "^1.10.52"
+            },
+            "type": "library",
+            "autoload": {
+                "psr-4": {
+                    "PHPUnit\\Architecture\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Ni Shi",
+                    "email": "futik0ma011@gmail.com"
+                },
+                {
+                    "name": "Nuno Maduro",
+                    "email": "enunomaduro@gmail.com"
+                }
+            ],
+            "description": "Methods for testing application architecture",
+            "keywords": [
+                "architecture",
+                "phpunit",
+                "stucture",
+                "test",
+                "testing"
+            ],
+            "support": {
+                "issues": "https://github.com/ta-tikoma/phpunit-architecture-test/issues",
+                "source": "https://github.com/ta-tikoma/phpunit-architecture-test/tree/0.8.7"
+            },
+            "time": "2026-02-17T17:25:14+00:00"
+        },
+        {
+            "name": "theseer/tokenizer",
+            "version": "2.0.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/theseer/tokenizer.git",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/theseer/tokenizer/zipball/7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
+                "reference": "7989e43bf381af0eac72e4f0ca5bcbfa81658be4",
                 "shasum": ""
             },
             "require": {
                 "ext-dom": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
-                "php": "^7.2 || ^8.0"
+                "php": "^8.1"
             },
             "type": "library",
             "autoload": {
@@ -11938,7 +12982,7 @@
             "description": "A small library for converting tokenized PHP source code into XML and potentially other formats",
             "support": {
                 "issues": "https://github.com/theseer/tokenizer/issues",
-                "source": "https://github.com/theseer/tokenizer/tree/1.3.1"
+                "source": "https://github.com/theseer/tokenizer/tree/2.0.1"
             },
             "funding": [
                 {
@@ -11946,7 +12990,73 @@
                     "type": "github"
                 }
             ],
-            "time": "2025-11-17T20:03:58+00:00"
+            "time": "2025-12-08T11:19:18+00:00"
+        },
+        {
+            "name": "webmozart/assert",
+            "version": "2.4.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/webmozarts/assert.git",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/webmozarts/assert/zipball/2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "reference": "2ccb7c2e821038c03a3e6e1700c570c158c55f70",
+                "shasum": ""
+            },
+            "require": {
+                "ext-ctype": "*",
+                "ext-date": "*",
+                "ext-filter": "*",
+                "php": "^8.2"
+            },
+            "suggest": {
+                "ext-intl": "",
+                "ext-simplexml": "",
+                "ext-spl": ""
+            },
+            "type": "library",
+            "extra": {
+                "psalm": {
+                    "pluginClass": "Webmozart\\Assert\\PsalmPlugin"
+                },
+                "branch-alias": {
+                    "dev-master": "2.0-dev",
+                    "dev-feature/2-0": "2.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Webmozart\\Assert\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Bernhard Schussek",
+                    "email": "bschussek@gmail.com"
+                },
+                {
+                    "name": "Woody Gilk",
+                    "email": "woody.gilk@gmail.com"
+                }
+            ],
+            "description": "Assertions to validate method input/output with nice error messages.",
+            "keywords": [
+                "assert",
+                "check",
+                "validate"
+            ],
+            "support": {
+                "issues": "https://github.com/webmozarts/assert/issues",
+                "source": "https://github.com/webmozarts/assert/tree/2.4.1"
+            },
+            "time": "2026-06-15T15:31:57+00:00"
         }
     ],
     "aliases": [],
@@ -11958,5 +13068,5 @@
         "php": "^8.3"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }

--- a/database/factories/AdFactory.php
+++ b/database/factories/AdFactory.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace Database\Factories;
+
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Ad>
+ */
+class AdFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'priority' => fake()->numberBetween(1, 10),
+            'name' => fake()->company(),
+            'type' => fake()->randomElement(['banner', 'photo']),
+            'url' => fake()->url(),
+            'img' => 'ads/'.fake()->uuid().'.jpg',
+            'query' => 'select * from photos limit 1',
+        ];
+    }
+}

--- a/database/factories/AnalyticFactory.php
+++ b/database/factories/AnalyticFactory.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Analytic>
+ *
+ * Note: `ip`, `device`, browser/platform columns are guarded on the model but
+ * factories bypass mass-assignment protection, so they are set here directly.
+ */
+class AnalyticFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'ip' => fake()->ipv4(),
+            'device' => 'Desktop',
+            'brand_family' => 'Unknown',
+            'brand_model' => 'Unknown',
+            'browser_family' => 'Chrome',
+            'browser_version' => '120.0',
+            'platform_family' => 'Linux',
+            'platform_version' => '1.0',
+            'user_id' => User::factory(),
+            'photo_id' => Photo::factory(),
+        ];
+    }
+}

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Comment>
+ */
+class CommentFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'photo_id' => Photo::factory(),
+            'body' => fake()->sentence(),
+        ];
+    }
+}

--- a/database/factories/HubFactory.php
+++ b/database/factories/HubFactory.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Hub>
+ *
+ * WARNING: This factory only inserts a row into the primary `hubs` table. It
+ * does NOT provision the tenant database / DB user. For a fully working hub
+ * (tenant DB + tables) use the ProvisionsHubs::createHub() test helper instead.
+ * Use this factory for admin-context tests that merely list/paginate hubs.
+ */
+class HubFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'name' => 'hub'.fake()->unique()->numerify('######'),
+            'teacher_id' => User::factory()->teacher(),
+            'password' => 'secret'.fake()->numberBetween(1000, 9999),
+            'generation' => 1,
+            'query_level' => 1,
+        ];
+    }
+}

--- a/database/factories/LikeFactory.php
+++ b/database/factories/LikeFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Like>
+ */
+class LikeFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'photo_id' => Photo::factory(),
+        ];
+    }
+}

--- a/database/factories/PhotoFactory.php
+++ b/database/factories/PhotoFactory.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Photo>
+ */
+class PhotoFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'user_id' => User::factory(),
+            'description' => fake()->sentence(),
+            'url' => 'photos/'.fake()->uuid().'.jpg',
+        ];
+    }
+}

--- a/database/factories/TagFactory.php
+++ b/database/factories/TagFactory.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\Photo;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends \Illuminate\Database\Eloquent\Factories\Factory<\App\Models\Tag>
+ */
+class TagFactory extends Factory
+{
+    public function definition(): array
+    {
+        return [
+            'photo_id' => Photo::factory(),
+            'name' => fake()->word(),
+        ];
+    }
+}

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -24,11 +24,15 @@ class UserFactory extends Factory
     public function definition(): array
     {
         return [
+            'username' => fake()->unique()->userName(),
             'name' => fake()->name(),
             'email' => fake()->unique()->safeEmail(),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),
+            'role' => 'user',
+            'is_active' => true,
+            'avatar' => 'avatar.png',
         ];
     }
 
@@ -40,5 +44,37 @@ class UserFactory extends Factory
         return $this->state(fn (array $attributes) => [
             'email_verified_at' => null,
         ]);
+    }
+
+    public function inactive(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'is_active' => false,
+        ]);
+    }
+
+    public function user(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => 'user']);
+    }
+
+    public function dba(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => 'dba']);
+    }
+
+    public function teacher(): static
+    {
+        return $this->state(fn (array $attributes) => [
+            'role' => 'teacher',
+            'hub_default_generation' => 1,
+            'hub_default_creating' => 'all_empty',
+            'hub_default_query_level' => 1,
+        ]);
+    }
+
+    public function admin(): static
+    {
+        return $this->state(fn (array $attributes) => ['role' => 'admin']);
     }
 }

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -19,11 +19,20 @@
     </source>
     <php>
         <env name="APP_ENV" value="testing"/>
+        <env name="APP_KEY" value="base64:6jtLi6JR/3IdWgLe5VJDtBI0Fe8BrxzmTo+Mk8xZMck="/>
+        <env name="APP_URL" value="http://localhost"/>
+        <env name="APP_URL_ADMIN" value="http://admin.localhost"/>
+        <env name="APP_URL_HUB" value="http://{subdomain}.localhost"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>
         <env name="CACHE_STORE" value="array"/>
+        <env name="DB_CONNECTION" value="mysql"/>
+        <env name="DB_HOST" value="127.0.0.1"/>
+        <env name="DB_PORT" value="3306"/>
         <env name="DB_DATABASE" value="testing"/>
+        <env name="DB_USERNAME" value="root"/>
+        <env name="DB_PASSWORD" value="root"/>
         <env name="MAIL_MAILER" value="array"/>
         <env name="PULSE_ENABLED" value="false"/>
         <env name="QUEUE_CONNECTION" value="sync"/>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -23,6 +23,10 @@
         <env name="APP_URL" value="http://localhost"/>
         <env name="APP_URL_ADMIN" value="http://admin.localhost"/>
         <env name="APP_URL_HUB" value="http://{subdomain}.localhost"/>
+        <env name="HUB_DEFAULT_GENERATION" value="1"/>
+        <env name="HUB_DOC_1_URL" value="https://wi-wissen.github.io/instahub-doc-de/"/>
+        <env name="HUB_DOC_2_URL" value="http://portal.localhost"/>
+        <env name="HUB_DOC_2_SECRET" value="123456"/>
         <env name="APP_MAINTENANCE_DRIVER" value="file"/>
         <env name="BCRYPT_ROUNDS" value="4"/>
         <env name="BROADCAST_CONNECTION" value="null"/>

--- a/resources/views/livewire/photo/show.blade.php
+++ b/resources/views/livewire/photo/show.blade.php
@@ -64,10 +64,12 @@
                                 <h4 class="my-0 fs-6 text-muted fst-italic">{{ __('Deleted User') }}</h4> 
                             @endif
                             <span>{!! $comment->html !!}</span>
-                            @if(!$readonly && $admin)
-                                <a wire:click.prevent="deleteComment({{ $comment->id }})" href="#" class="float-right">
-                                    <span>x</span>
-                                </a>
+                            @if(!$readonly)
+                                @can('delete', $comment)
+                                    <a wire:click.prevent="deleteComment({{ $comment->id }})" href="#" class="float-right">
+                                        <span>x</span>
+                                    </a>
+                                @endcan
                             @endif
                         </div>
                     </div>

--- a/tests/Feature/Admin/AdminControllerTest.php
+++ b/tests/Feature/Admin/AdminControllerTest.php
@@ -1,0 +1,74 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+// --- trimAnalytics (admin-context: /dba/trimanalytics, role:admin) ---
+
+test('admin can trigger trimAnalytics when there are no hubs', function () {
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/dba/trimanalytics')
+        ->assertOk();
+});
+
+test('non-admin cannot trigger trimAnalytics', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/dba/trimanalytics')
+        ->assertRedirect('/');
+});
+
+test('guest cannot trigger trimAnalytics', function () {
+    $this->get('http://admin.localhost/dba/trimanalytics')
+        ->assertRedirect('/login');
+});
+
+// --- redirect (hubs/{hub}/dba/redirect, role:teacher) ---
+// Building the redirect URL never touches the tenant DB, so a plain
+// (non-provisioned) Hub row is sufficient here.
+
+test('teacher can redirect into their own hub', function () {
+    $teacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $teacher->id, 'name' => 'myredirecthub']);
+
+    $response = $this->actingAs($teacher)
+        ->get("http://admin.localhost/hubs/{$hub->id}/dba/redirect");
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toContain('myredirecthub.localhost/login/');
+});
+
+test('admin can redirect into any hub', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $teacher->id, 'name' => 'adminredirecthub']);
+
+    $response = $this->actingAs($admin)
+        ->get("http://admin.localhost/hubs/{$hub->id}/dba/redirect");
+
+    $response->assertRedirect();
+    expect($response->headers->get('Location'))->toContain('adminredirecthub.localhost/login/');
+});
+
+test('teacher cannot redirect into another teachers hub', function () {
+    $teacher = User::factory()->teacher()->create();
+    $otherTeacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/hubs/{$hub->id}/dba/redirect")
+        ->assertForbidden();
+});
+
+test('redirect stores a one-time auth token in cache', function () {
+    $teacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $teacher->id, 'name' => 'cachetokenhub']);
+
+    $this->actingAs($teacher)->get("http://admin.localhost/hubs/{$hub->id}/dba/redirect");
+
+    expect(Cache::has('hub-'.$hub->id.'-auth-token'))->toBeTrue();
+});

--- a/tests/Feature/Admin/FileControllerTest.php
+++ b/tests/Feature/Admin/FileControllerTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+test('admin can fetch an uploaded avatar', function () {
+    Storage::fake('local');
+    Storage::disk('local')->put('avatars/myavatar.webp', 'fake-image-bytes');
+
+    $admin = User::factory()->admin()->create();
+    $target = User::factory()->create(['avatar' => 'avatars/myavatar.webp']);
+
+    $response = $this->actingAs($admin)->get('http://admin.localhost/avatars/myavatar.webp');
+
+    $response->assertOk();
+    expect($response->getContent())->toBe('fake-image-bytes');
+});
+
+test('avatar lookup 404s for an unknown filename', function () {
+    Storage::fake('local');
+    $admin = User::factory()->admin()->create();
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/avatars/does-not-exist.webp')
+        ->assertNotFound();
+});
+
+test('non-admin cannot fetch avatars in the admin area', function () {
+    Storage::fake('local');
+    Storage::disk('local')->put('avatars/myavatar.webp', 'fake-image-bytes');
+
+    $teacher = User::factory()->teacher()->create();
+    User::factory()->create(['avatar' => 'avatars/myavatar.webp']);
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/avatars/myavatar.webp')
+        ->assertRedirect('/');
+});
+
+test('guest cannot fetch avatars in the admin area', function () {
+    $this->get('http://admin.localhost/avatars/myavatar.webp')
+        ->assertRedirect('/login');
+});

--- a/tests/Feature/Admin/HubControllerTest.php
+++ b/tests/Feature/Admin/HubControllerTest.php
@@ -1,0 +1,201 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+
+// --- index ---
+
+test('guest is redirected away from the admin hub listing', function () {
+    $this->get('http://admin.localhost/')->assertRedirect('/login');
+});
+
+test('plain user cannot view the admin hub listing', function () {
+    $user = User::factory()->user()->create();
+
+    $this->actingAs($user)
+        ->get('http://admin.localhost/')
+        ->assertRedirect('/');
+});
+
+// NOTE: listing hubs that actually appear as rows renders the
+// `livewire.hub.index` table, which reads real per-hub computed attributes
+// (`$hub->admin`, `->activated`, `->readonly`, `->hasWorkingUser`) that open a
+// real connection to that hub's tenant database. Hub::factory() rows have no
+// such database, so those listing scenarios are covered with real
+// provisioned hubs in tests/Feature/Hub/AdminControllers/HubControllerIndexTest.php
+// instead. Here we only cover the always-empty-listing paths.
+
+test('teacher sees an empty hub listing when they have no hubs', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/')
+        ->assertOk();
+});
+
+// --- create ---
+
+test('create hub form renders for a guest', function () {
+    $this->get('http://admin.localhost/hubs/create')->assertOk();
+});
+
+test('create hub form renders for an authenticated teacher', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/hubs/create')
+        ->assertOk();
+});
+
+// --- store: validation (no tenant DB is ever provisioned for these) ---
+
+test('store fails validation when hub name is not alphanumeric', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'not valid!!',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+
+    $response->assertSessionHasErrors('hub');
+    expect(Hub::where('name', 'not valid!!')->exists())->toBeFalse();
+});
+
+test('store fails validation when hub name is already taken', function () {
+    $teacher = User::factory()->teacher()->create();
+    $existing = Hub::factory()->create(['name' => 'takenhub']);
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'takenhub',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+
+    $response->assertSessionHasErrors('hub');
+});
+
+test('store fails validation when password is too short or unconfirmed', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'freshhubname',
+        'password' => 'abc',
+        'password_confirmation' => 'abc',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+
+    $response->assertSessionHasErrors('password');
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'freshhubname',
+        'password' => 'secret123',
+        'password_confirmation' => 'doesnotmatch',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+
+    $response->assertSessionHasErrors('password');
+    expect(Hub::where('name', 'freshhubname')->exists())->toBeFalse();
+});
+
+test('store fails validation when the referenced teacher does not exist or is inactive', function () {
+    $teacher = User::factory()->teacher()->create();
+    $inactiveTeacher = User::factory()->teacher()->inactive()->create();
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'freshhubname',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => 'no-such-username',
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+    $response->assertSessionHasErrors('teacher');
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'freshhubname',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $inactiveTeacher->username,
+        'username' => 'admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+    $response->assertSessionHasErrors('teacher');
+
+    expect(Hub::where('name', 'freshhubname')->exists())->toBeFalse();
+});
+
+test('store fails validation when the username is not admin', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'freshhubname',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'not-admin',
+        'name' => 'Admin',
+        'email' => 'admin@example.test',
+    ]);
+
+    $response->assertSessionHasErrors('username');
+    expect(Hub::where('name', 'freshhubname')->exists())->toBeFalse();
+});
+
+// --- show ---
+// A successful `show` renders the `livewire.hub.show` component, which also
+// opens a real connection to the hub's tenant database (to list its tables).
+// That scenario lives in Feature/Hub/AdminControllers; the unauthorized path
+// below is rejected by the `can:view` policy before any of that happens, so
+// it is safe with a plain, non-provisioned Hub::factory() row.
+
+test('teacher cannot view another teachers hub', function () {
+    $teacher = User::factory()->teacher()->create();
+    $otherTeacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/hubs/{$hub->id}")
+        ->assertForbidden();
+});
+
+// --- destroy: authorization only (unauthorized requests never reach the
+// tenant-DB-dropping code, so no real tenant DB is needed here) ---
+
+test('teacher cannot destroy another teachers hub', function () {
+    $teacher = User::factory()->teacher()->create();
+    $otherTeacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+    $this->actingAs($teacher)
+        ->delete("http://admin.localhost/hubs/{$hub->id}")
+        ->assertForbidden();
+
+    expect(Hub::find($hub->id))->not->toBeNull();
+});
+
+test('guest cannot destroy a hub', function () {
+    $teacher = User::factory()->teacher()->create();
+    $hub = Hub::factory()->create(['teacher_id' => $teacher->id]);
+
+    $this->delete("http://admin.localhost/hubs/{$hub->id}")
+        ->assertRedirect('/login');
+
+    expect(Hub::find($hub->id))->not->toBeNull();
+});

--- a/tests/Feature/Admin/StaticControllerTest.php
+++ b/tests/Feature/Admin/StaticControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+test('welcome page renders for guests', function () {
+    $this->get('http://localhost/')->assertOk()->assertSee('InstaHub');
+});
+
+test('about page renders', function () {
+    $this->get('http://localhost/about')->assertOk();
+});
+
+test('noad page renders', function () {
+    $this->get('http://localhost/noad')->assertOk();
+});
+
+test('documentation redirect sends generation 1 to its plain configured url', function () {
+    $response = $this->get('http://localhost/documentation/redirect/1');
+
+    $response->assertRedirect(config('hub.generations.1.url'));
+});
+
+test('documentation redirect signs the url with a hash for generations that have a secret', function () {
+    $response = $this->get('http://localhost/documentation/redirect/2');
+
+    $response->assertRedirect();
+    $location = $response->headers->get('Location');
+
+    expect($location)->toContain(config('hub.generations.2.url'));
+    expect($location)->toContain('timestamp=');
+    expect($location)->toContain('hash=');
+});
+
+test('documentation redirect forwards a return_url when given', function () {
+    $response = $this->get('http://localhost/documentation/redirect/1?return_url='.urlencode('http://example.test/back'));
+
+    $location = $response->headers->get('Location');
+
+    expect($location)->toContain('return_url=');
+});

--- a/tests/Feature/Admin/UserControllerTest.php
+++ b/tests/Feature/Admin/UserControllerTest.php
@@ -1,0 +1,181 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+// --- index (role:admin) ---
+
+test('admin can list all users', function () {
+    // The shared admin-area navbar links to the documentation for any
+    // "teacher-or-above" user (Auth::user()->allowed('teacher')) using their
+    // hub_default_generation, so an admin needs one set too (real admin
+    // accounts are promoted teachers and already have it).
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $other = User::factory()->create(['username' => 'zulu']);
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/explore/users')
+        ->assertOk()
+        ->assertSee($other->username);
+});
+
+test('non-admin cannot list all users', function () {
+    // /explore/users sits behind the role:admin route middleware, which
+    // redirects (not 403s) when the role check fails.
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/explore/users')
+        ->assertRedirect('/');
+});
+
+test('admin can filter the user listing by starting letter', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $alice = User::factory()->create(['username' => 'alice123']);
+    $bob = User::factory()->create(['username' => 'bob456']);
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/explore/users/letter/a')
+        ->assertOk()
+        ->assertSee($alice->username)
+        ->assertDontSee($bob->username);
+});
+
+// --- show / edit / update / destroy (role:teacher; policy checks admin or self) ---
+
+test('teacher can view their own profile in the admin area', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/{$teacher->username}")
+        ->assertOk();
+});
+
+test('teacher cannot view another users profile in the admin area', function () {
+    $teacher = User::factory()->teacher()->create();
+    $other = User::factory()->create();
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/{$other->username}")
+        ->assertForbidden();
+});
+
+test('admin can view any users profile', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $other = User::factory()->create();
+
+    $this->actingAs($admin)
+        ->get("http://admin.localhost/{$other->username}")
+        ->assertOk();
+});
+
+test('teacher can edit and update their own profile', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/{$teacher->username}/edit")
+        ->assertOk();
+
+    $response = $this->actingAs($teacher)->put("http://admin.localhost/{$teacher->username}/update", [
+        'name' => 'Updated Name',
+        'email' => $teacher->email,
+    ]);
+
+    $response->assertRedirect();
+    expect($teacher->fresh()->name)->toBe('Updated Name');
+});
+
+test('teacher cannot update another users profile', function () {
+    $teacher = User::factory()->teacher()->create();
+    $other = User::factory()->create(['name' => 'Original']);
+
+    $this->actingAs($teacher)->put("http://admin.localhost/{$other->username}/update", [
+        'name' => 'Hacked Name',
+        'email' => $other->email,
+    ])->assertForbidden();
+
+    expect($other->fresh()->name)->toBe('Original');
+});
+
+test('only admin can activate a user', function () {
+    // Activating a user flips it to `is_active = true`, which triggers a
+    // UserActivated notification; building its URL falls back to reading
+    // $_SERVER['HTTP_HOST'] directly (see App\Helpers\HubHelper::url()).
+    // Laravel's HTTP test client never populates that PHP superglobal (only
+    // the ProvisionsHubs onHub()/withinHub() helpers do, for hub-domain
+    // tests), so we set it here too; TestCase::tearDown() unsets it again.
+    $_SERVER['HTTP_HOST'] = 'admin.localhost';
+
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->teacher()->create();
+    $target = User::factory()->inactive()->create();
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/{$target->username}/activate")
+        ->assertRedirect('/');
+    expect($target->fresh()->is_active)->toBeFalsy();
+
+    $this->actingAs($admin)
+        ->get("http://admin.localhost/{$target->username}/activate");
+    expect($target->fresh()->is_active)->toBeTruthy();
+});
+
+test('only admin can deactivate a user', function () {
+    $admin = User::factory()->admin()->create();
+    $target = User::factory()->create(['is_active' => true]);
+
+    $this->actingAs($admin)
+        ->get("http://admin.localhost/{$target->username}/deactivate");
+
+    expect($target->fresh()->is_active)->toBeFalsy();
+});
+
+test('only admin can destroy a user', function () {
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->teacher()->create();
+    $target = User::factory()->create();
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/{$target->username}/destroy")
+        ->assertForbidden();
+    expect(User::find($target->id))->not->toBeNull();
+
+    $this->actingAs($admin)
+        ->get("http://admin.localhost/{$target->username}/destroy");
+    expect(User::find($target->id))->toBeNull();
+});
+
+// --- password (role:teacher, any authenticated teacher manages their own) ---
+
+test('teacher can view the change password form', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/password')
+        ->assertOk();
+});
+
+test('teacher can change their password with correct old password', function () {
+    $teacher = User::factory()->teacher()->create(['password' => Hash::make('old-password')]);
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/password', [
+        'old_password' => 'old-password',
+        'password' => 'brand-new-password',
+        'password_confirmation' => 'brand-new-password',
+    ]);
+
+    $response->assertRedirect('/');
+    expect(Hash::check('brand-new-password', $teacher->fresh()->password))->toBeTrue();
+});
+
+test('teacher password change fails with wrong old password', function () {
+    $teacher = User::factory()->teacher()->create(['password' => Hash::make('old-password')]);
+
+    $this->actingAs($teacher)->post('http://admin.localhost/password', [
+        'old_password' => 'wrong-password',
+        'password' => 'brand-new-password',
+        'password_confirmation' => 'brand-new-password',
+    ]);
+
+    expect(Hash::check('old-password', $teacher->fresh()->password))->toBeTrue();
+});

--- a/tests/Feature/Auth/ConfirmPasswordTest.php
+++ b/tests/Feature/Auth/ConfirmPasswordTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\User;
+
+it('shows the password confirmation form to an authenticated user', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('http://localhost/password/confirm');
+
+    $response->assertOk();
+    $response->assertViewIs('auth.passwords.confirm');
+});
+
+it('redirects a guest away from the confirm-password form to the login page', function () {
+    $response = $this->get('http://localhost/password/confirm');
+
+    $response->assertRedirect('http://localhost/login');
+});
+
+it('confirms the password when the current password is correct', function () {
+    $user = User::factory()->create(['password' => bcrypt('correct-password')]);
+
+    $response = $this->actingAs($user)->post('http://localhost/password/confirm', [
+        'password' => 'correct-password',
+    ]);
+
+    $response->assertRedirect('/');
+    expect(session('auth.password_confirmed_at'))->not->toBeNull();
+});
+
+it('fails to confirm the password when the current password is wrong', function () {
+    $user = User::factory()->create(['password' => bcrypt('correct-password')]);
+
+    $response = $this->actingAs($user)->post('http://localhost/password/confirm', [
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertSessionHasErrors('password');
+    expect(session('auth.password_confirmed_at'))->toBeNull();
+});

--- a/tests/Feature/Auth/EmailVerificationTest.php
+++ b/tests/Feature/Auth/EmailVerificationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+
+function signedVerificationUrl(User $user): string
+{
+    return URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1($user->email)]
+    );
+}
+
+it('shows the verification notice to an unverified user', function () {
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->actingAs($user)->get('http://localhost/email/verify');
+
+    $response->assertOk();
+    $response->assertViewIs('auth.verify');
+});
+
+it('redirects an already verified user away from the verification notice', function () {
+    $user = User::factory()->create(); // verified by default via the factory
+
+    $response = $this->actingAs($user)->get('http://localhost/email/verify');
+
+    $response->assertRedirect('/');
+});
+
+it('redirects a guest trying to view the verification notice to the login form', function () {
+    $response = $this->get('http://localhost/email/verify');
+
+    $response->assertRedirect('http://localhost/login');
+});
+
+it('marks the email as verified when visiting a valid signed verification link', function () {
+    $user = User::factory()->unverified()->create();
+    $url = signedVerificationUrl($user);
+
+    $response = $this->actingAs($user)->get($url);
+
+    $response->assertRedirect('/');
+    $response->assertSessionHas('verified', true);
+    expect($user->fresh()->hasVerifiedEmail())->toBeTrue();
+});
+
+it('rejects a verification link with a tampered hash', function () {
+    $user = User::factory()->unverified()->create();
+    $badUrl = URL::temporarySignedRoute(
+        'verification.verify',
+        now()->addMinutes(60),
+        ['id' => $user->id, 'hash' => sha1('someone-else@example.com')]
+    );
+
+    $response = $this->actingAs($user)->get($badUrl);
+
+    $response->assertForbidden();
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
+});
+
+it('rejects an unsigned (tampered) verification link', function () {
+    $user = User::factory()->unverified()->create();
+
+    $response = $this->actingAs($user)->get("http://localhost/email/verify/{$user->id}/".sha1($user->email));
+
+    $response->assertForbidden();
+    expect($user->fresh()->hasVerifiedEmail())->toBeFalse();
+});
+
+it('does nothing but redirect when visiting the verify link as an already verified user', function () {
+    $user = User::factory()->create(); // already verified
+    $url = signedVerificationUrl($user);
+
+    $response = $this->actingAs($user)->get($url);
+
+    $response->assertRedirect('/');
+    $response->assertSessionMissing('verified');
+});
+
+it('resends the verification email to an unverified authenticated user', function () {
+    $user = User::factory()->unverified()->create();
+    Notification::fake();
+
+    $response = $this->actingAs($user)->from('http://localhost/email/verify')->post('http://localhost/email/resend');
+
+    $response->assertRedirect('http://localhost/email/verify');
+    $response->assertSessionHas('resent', true);
+    Notification::assertSentTo($user, VerifyEmail::class);
+});
+
+it('does not resend the verification email to an already verified user', function () {
+    $user = User::factory()->create();
+    Notification::fake();
+
+    $response = $this->actingAs($user)->post('http://localhost/email/resend');
+
+    $response->assertRedirect('/');
+    Notification::assertNothingSent();
+});
+
+it('redirects unverified users away from routes protected by the verified middleware', function () {
+    $teacher = User::factory()->teacher()->unverified()->create();
+
+    $response = $this->actingAs($teacher)->get('http://admin.localhost/password');
+
+    // route() resolves against the current request's host, not a forced root.
+    $response->assertRedirect('http://admin.localhost/email/verify');
+});

--- a/tests/Feature/Auth/ForgotPasswordTest.php
+++ b/tests/Feature/Auth/ForgotPasswordTest.php
@@ -1,0 +1,52 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Support\Facades\Notification;
+
+it('shows the forgot-password form', function () {
+    $this->get('http://localhost/password/reset')
+        ->assertOk()
+        ->assertViewIs('auth.passwords.email');
+});
+
+it('sends a reset link notification to an active, existing user', function () {
+    $user = User::factory()->create(['email' => 'active@example.com', 'is_active' => true]);
+    Notification::fake();
+
+    $response = $this->post('http://localhost/password/email', [
+        'email' => 'active@example.com',
+    ]);
+
+    $response->assertSessionHas('status', __('passwords.sent'));
+    Notification::assertSentTo($user, ResetPassword::class);
+});
+
+it('fails with the "no user" message for an unknown email', function () {
+    Notification::fake();
+
+    $response = $this->post('http://localhost/password/email', [
+        'email' => 'unknown@example.com',
+    ]);
+
+    $response->assertSessionHasErrors(['email' => __('passwords.user')]);
+    Notification::assertNothingSent();
+});
+
+it('fails with the "not active" message for an inactive user', function () {
+    User::factory()->inactive()->create(['email' => 'inactive@example.com']);
+    Notification::fake();
+
+    $response = $this->post('http://localhost/password/email', [
+        'email' => 'inactive@example.com',
+    ]);
+
+    $response->assertSessionHasErrors(['email' => __('passwords.active')]);
+    Notification::assertNothingSent();
+});
+
+it('requires a valid email to request a reset link', function () {
+    $response = $this->post('http://localhost/password/email', ['email' => 'not-an-email']);
+
+    $response->assertSessionHasErrors('email');
+});

--- a/tests/Feature/Auth/IsHubMiddlewareTest.php
+++ b/tests/Feature/Auth/IsHubMiddlewareTest.php
@@ -1,0 +1,36 @@
+<?php
+
+use App\Http\Middleware\IsHubMiddleware;
+use Illuminate\Http\Request;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\HttpKernel\Exception\HttpException;
+
+it('aborts with 403 when the request URL starts with the admin URL', function () {
+    $middleware = new IsHubMiddleware;
+    $request = Request::create(config('app.url_admin').'/some/path');
+
+    try {
+        $middleware->handle($request, fn ($req) => $req);
+        $this->fail('Expected an HttpException to be thrown.');
+    } catch (HttpException $e) {
+        expect($e->getStatusCode())->toBe(403);
+    }
+});
+
+it('passes the request through when the URL does not start with the admin URL', function () {
+    $middleware = new IsHubMiddleware;
+    $request = Request::create('http://localhost/foo');
+
+    $result = $middleware->handle($request, fn ($req) => new Response('passed-through:'.$req->getUri()));
+
+    expect($result->getContent())->toBe('passed-through:http://localhost/foo');
+});
+
+it('passes a hub-subdomain request through untouched', function () {
+    $middleware = new IsHubMiddleware;
+    $request = Request::create('http://myhub.localhost/');
+
+    $result = $middleware->handle($request, fn ($req) => new Response('ok'));
+
+    expect($result->getContent())->toBe('ok');
+});

--- a/tests/Feature/Auth/LoginTest.php
+++ b/tests/Feature/Auth/LoginTest.php
@@ -1,0 +1,129 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\RateLimiter;
+
+it('shows the login form', function () {
+    $this->get('http://localhost/login')
+        ->assertOk()
+        ->assertViewIs('auth.login');
+});
+
+it('logs in an active, existing user with correct credentials', function () {
+    $user = User::factory()->create([
+        'username' => 'janedoe',
+        'password' => bcrypt('correct-password'),
+        'is_active' => true,
+    ]);
+
+    $response = $this->post('http://localhost/login', [
+        'username' => 'janedoe',
+        'password' => 'correct-password',
+    ]);
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($user);
+});
+
+it('rejects login with a wrong password and flashes the generic auth.failed message', function () {
+    User::factory()->create([
+        'username' => 'janedoe',
+        'password' => bcrypt('correct-password'),
+        'is_active' => true,
+    ]);
+
+    $response = $this->from('http://localhost/login')->post('http://localhost/login', [
+        'username' => 'janedoe',
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertRedirect('http://localhost/login');
+    $response->assertSessionHasErrors(['username' => __('auth.failed')]);
+    $this->assertGuest();
+});
+
+it('rejects login for a username that does not exist', function () {
+    $response = $this->from('http://localhost/login')->post('http://localhost/login', [
+        'username' => 'nobody-here',
+        'password' => 'whatever',
+    ]);
+
+    $response->assertSessionHasErrors(['username' => __('auth.failed')]);
+    $this->assertGuest();
+});
+
+it('rejects login for an inactive user even with the correct password', function () {
+    User::factory()->inactive()->create([
+        'username' => 'inactiveuser',
+        'password' => bcrypt('correct-password'),
+    ]);
+
+    $response = $this->from('http://localhost/login')->post('http://localhost/login', [
+        'username' => 'inactiveuser',
+        'password' => 'correct-password',
+    ]);
+
+    // the "exists" rule is scoped with `is_active,1`, so an inactive user
+    // fails validation the same way a non-existent user would.
+    $response->assertSessionHasErrors(['username' => __('auth.failed')]);
+    $this->assertGuest();
+});
+
+it('requires username and password', function () {
+    $response = $this->post('http://localhost/login', []);
+
+    $response->assertSessionHasErrors(['username', 'password']);
+});
+
+it('locks out the login form after too many failed attempts', function () {
+    RateLimiter::clear('janedoe|127.0.0.1');
+
+    User::factory()->create([
+        'username' => 'janedoe',
+        'password' => bcrypt('correct-password'),
+        'is_active' => true,
+    ]);
+
+    for ($i = 0; $i < 5; $i++) {
+        $this->post('http://localhost/login', [
+            'username' => 'janedoe',
+            'password' => 'wrong-password',
+        ]);
+    }
+
+    $response = $this->post('http://localhost/login', [
+        'username' => 'janedoe',
+        'password' => 'wrong-password',
+    ]);
+
+    $response->assertStatus(302);
+    $response->assertSessionHasErrors('username');
+    $errors = session('errors')->getBag('default')->get('username');
+    expect($errors[0])->toContain('Too many login attempts');
+
+    RateLimiter::clear('janedoe|127.0.0.1');
+});
+
+it('redirects an already authenticated user away from the login form', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('http://localhost/login');
+
+    $response->assertRedirect('/');
+});
+
+it('logs out an authenticated user', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->post('http://localhost/logout');
+
+    $response->assertRedirect('/');
+    $this->assertGuest();
+});
+
+it('does not allow a guest to log out', function () {
+    $response = $this->post('http://localhost/logout');
+
+    // "auth" middleware redirects guests to the login route.
+    $response->assertRedirect('http://localhost/login');
+});

--- a/tests/Feature/Auth/LoginWithTokenTest.php
+++ b/tests/Feature/Auth/LoginWithTokenTest.php
@@ -1,0 +1,54 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Support\Facades\Cache;
+
+// Outside of a hub, RequestHub::id() returns null, so the cache key used by
+// LoginController@loginWithToken is always "hub--auth-token" in these tests.
+const HUB_TOKEN_CACHE_KEY = 'hub--auth-token';
+
+it('logs the dba in when the token matches the cached token and consumes it', function () {
+    $dba = User::factory()->dba()->create();
+
+    Cache::put(HUB_TOKEN_CACHE_KEY, 'secret-token', now()->addMinutes(5));
+
+    $response = $this->get('http://localhost/login/secret-token');
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($dba);
+    expect(Cache::has(HUB_TOKEN_CACHE_KEY))->toBeFalse();
+});
+
+it('fails when the token does not match the cached token', function () {
+    User::factory()->dba()->create();
+
+    Cache::put(HUB_TOKEN_CACHE_KEY, 'secret-token', now()->addMinutes(5));
+
+    $response = $this->from('http://localhost/login')->get('http://localhost/login/wrong-token');
+
+    $response->assertSessionHasErrors('username');
+    $this->assertGuest();
+    // the valid token is untouched since it never matched
+    expect(Cache::has(HUB_TOKEN_CACHE_KEY))->toBeTrue();
+});
+
+it('fails when there is no cached token at all', function () {
+    Cache::forget(HUB_TOKEN_CACHE_KEY);
+
+    $response = $this->from('http://localhost/login')->get('http://localhost/login/anything');
+
+    $response->assertSessionHasErrors('username');
+    $this->assertGuest();
+});
+
+it('is reachable even when a user is already authenticated (no guest middleware)', function () {
+    $existing = User::factory()->create();
+    $dba = User::factory()->dba()->create();
+
+    Cache::put(HUB_TOKEN_CACHE_KEY, 'secret-token', now()->addMinutes(5));
+
+    $response = $this->actingAs($existing)->get('http://localhost/login/secret-token');
+
+    $response->assertRedirect('/');
+    $this->assertAuthenticatedAs($dba);
+});

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -1,0 +1,131 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\NewUser;
+use Illuminate\Auth\Notifications\VerifyEmail;
+use Illuminate\Support\Facades\Notification;
+use Ossycodes\FriendlyCaptcha\FriendlyCaptcha as FriendlyCaptchaClient;
+
+/**
+ * The registration form requires a FriendlyCaptcha solution, which is
+ * verified against a real external HTTP endpoint by default. We swap the
+ * bound client for a Mockery double so tests never hit the network.
+ */
+function fakeCaptcha(bool $success = true): void
+{
+    $mock = Mockery::mock(FriendlyCaptchaClient::class);
+    $mock->shouldReceive('verifyResponse')->andReturn($mock);
+    $mock->shouldReceive('isSuccess')->andReturn($success);
+
+    if (! $success) {
+        $mock->shouldReceive('getErrors')->andReturn(['solution_invalid']);
+    }
+
+    app()->instance(FriendlyCaptchaClient::class, $mock);
+}
+
+function validRegistrationPayload(array $overrides = []): array
+{
+    return array_merge([
+        'username' => 'newteacher',
+        'name' => 'New Teacher',
+        'email' => 'newteacher@example.com',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'messageToAdmin' => 'Please activate my account.',
+        'frc-captcha-solution' => 'solution',
+    ], $overrides);
+}
+
+it('shows the registration form', function () {
+    $this->get('http://localhost/register')
+        ->assertOk()
+        ->assertViewIs('auth.register');
+});
+
+it('registers a new teacher account on the main domain, notifies the admin and sends a verification email', function () {
+    $admin = User::factory()->admin()->create();
+    Notification::fake();
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload());
+
+    $response->assertRedirect('/');
+
+    $user = User::where('email', 'newteacher@example.com')->first();
+    expect($user)->not->toBeNull();
+    expect($user->role)->toBe('teacher');
+    expect($user->username)->toBe('newteacher');
+    // is_active mirrors app()->environment('local'), which is false in tests.
+    expect((bool) $user->is_active)->toBeFalse();
+    expect($user->email_verified_at)->toBeNull();
+
+    Notification::assertSentTo($admin, NewUser::class);
+    Notification::assertSentTo($user, VerifyEmail::class);
+
+    // the account is inactive, so it must not be logged in automatically.
+    $this->assertGuest();
+});
+
+it('fails registration validation when required fields are missing', function () {
+    $response = $this->post('http://localhost/register', []);
+
+    $response->assertSessionHasErrors(['username', 'name', 'email', 'password']);
+    $this->assertGuest();
+});
+
+it('fails registration when the password confirmation does not match', function () {
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload([
+        'password' => 'secret123',
+        'password_confirmation' => 'does-not-match',
+    ]));
+
+    $response->assertSessionHasErrors('password');
+});
+
+it('fails registration when the username is already taken', function () {
+    User::factory()->create(['username' => 'newteacher']);
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload());
+
+    $response->assertSessionHasErrors('username');
+});
+
+it('fails registration when the email is already taken', function () {
+    User::factory()->create(['email' => 'newteacher@example.com']);
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload());
+
+    $response->assertSessionHasErrors('email');
+});
+
+it('fails registration when the username contains unsafe characters', function () {
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload([
+        'username' => 'not a safe name',
+    ]));
+
+    $response->assertSessionHasErrors('username');
+});
+
+it('fails registration when the captcha verification fails', function () {
+    fakeCaptcha(false);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload());
+
+    $response->assertSessionHasErrors('frc-captcha-solution');
+    $this->assertGuest();
+});
+
+it('redirects an already authenticated user away from the registration form', function () {
+    $user = User::factory()->create();
+
+    $response = $this->actingAs($user)->get('http://localhost/register');
+
+    $response->assertRedirect('/');
+});

--- a/tests/Feature/Auth/RegisterTest.php
+++ b/tests/Feature/Auth/RegisterTest.php
@@ -122,6 +122,30 @@ it('fails registration when the captcha verification fails', function () {
     $this->assertGuest();
 });
 
+it('rejects registration when the birthday is not a valid Y-m-d date', function () {
+    fakeCaptcha(true);
+
+    $response = $this->post('http://localhost/register', validRegistrationPayload([
+        'birthday' => '01.01.2000',
+    ]));
+
+    $response->assertSessionHasErrors('birthday');
+    $this->assertGuest();
+});
+
+it('stores a valid birthday on the newly registered account', function () {
+    User::factory()->admin()->create();
+    Notification::fake();
+    fakeCaptcha(true);
+
+    $this->post('http://localhost/register', validRegistrationPayload([
+        'birthday' => '2000-01-01',
+    ]))->assertRedirect('/');
+
+    $user = User::where('email', 'newteacher@example.com')->first();
+    expect($user->birthday->format('Y-m-d'))->toBe('2000-01-01');
+});
+
 it('redirects an already authenticated user away from the registration form', function () {
     $user = User::factory()->create();
 

--- a/tests/Feature/Auth/ResetPasswordTest.php
+++ b/tests/Feature/Auth/ResetPasswordTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword as ResetPasswordNotification;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\Password;
+
+function capturePasswordResetToken(User $user): string
+{
+    Notification::fake();
+
+    Password::broker()->sendResetLink(['email' => $user->email]);
+
+    $token = null;
+    Notification::assertSentTo($user, ResetPasswordNotification::class, function ($notification) use (&$token) {
+        $token = $notification->token;
+
+        return true;
+    });
+
+    Notification::fake(); // reset the fake so the reset itself doesn't record this notification
+
+    return $token;
+}
+
+it('shows the reset-password form for a token', function () {
+    $response = $this->get('http://localhost/password/reset/some-token?email=someone@example.com');
+
+    $response->assertOk();
+    $response->assertViewIs('auth.passwords.reset');
+    $response->assertViewHas('token', 'some-token');
+});
+
+it('resets the password with a valid token and logs the user in', function () {
+    $user = User::factory()->create(['email' => 'reset-me@example.com']);
+    $token = capturePasswordResetToken($user);
+
+    $response = $this->post('http://localhost/password/reset', [
+        'token' => $token,
+        'email' => 'reset-me@example.com',
+        'password' => 'brand-new-password',
+        'password_confirmation' => 'brand-new-password',
+    ]);
+
+    $response->assertRedirect('/');
+    $response->assertSessionHas('status', __('passwords.reset'));
+
+    $this->assertAuthenticatedAs($user->fresh());
+    expect(Hash::check('brand-new-password', $user->fresh()->password))->toBeTrue();
+});
+
+it('fails to reset the password with an invalid token', function () {
+    $user = User::factory()->create(['email' => 'reset-me@example.com']);
+
+    $response = $this->from('http://localhost/password/reset/bad-token')->post('http://localhost/password/reset', [
+        'token' => 'totally-bogus-token',
+        'email' => 'reset-me@example.com',
+        'password' => 'brand-new-password',
+        'password_confirmation' => 'brand-new-password',
+    ]);
+
+    $response->assertSessionHasErrors(['email' => __('passwords.token')]);
+    $this->assertGuest();
+    expect(Hash::check('brand-new-password', $user->fresh()->password))->toBeFalse();
+});
+
+it('requires matching password confirmation and a minimum length to reset', function () {
+    $user = User::factory()->create(['email' => 'reset-me@example.com']);
+    $token = capturePasswordResetToken($user);
+
+    $response = $this->post('http://localhost/password/reset', [
+        'token' => $token,
+        'email' => 'reset-me@example.com',
+        'password' => 'short',
+        'password_confirmation' => 'not-the-same',
+    ]);
+
+    $response->assertSessionHasErrors('password');
+});

--- a/tests/Feature/Auth/RoleMiddlewareTest.php
+++ b/tests/Feature/Auth/RoleMiddlewareTest.php
@@ -1,0 +1,83 @@
+<?php
+
+use App\Http\Middleware\Role;
+use App\Models\User;
+use Illuminate\Http\Request;
+
+it('allows a teacher to access a teacher-only admin-domain route', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $response = $this->actingAs($teacher)->get('http://admin.localhost/password');
+
+    $response->assertOk();
+    $response->assertViewIs('auth.passwords.set');
+});
+
+it('redirects a plain user away from a teacher-only admin-domain route and flashes an error', function () {
+    $user = User::factory()->user()->create();
+
+    $response = $this->actingAs($user)->get('http://admin.localhost/password');
+
+    $response->assertRedirect('http://admin.localhost');
+    $response->assertSessionHas('flash_notification', function ($messages) {
+        return $messages->first()->message === __('You are not allowed to do this!')
+            && $messages->first()->level === 'danger';
+    });
+});
+
+it('redirects a teacher away from an admin-only admin-domain route', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $response = $this->actingAs($teacher)->get('http://admin.localhost/explore/users');
+
+    $response->assertRedirect('http://admin.localhost');
+    $response->assertSessionHas('flash_notification');
+});
+
+it('allows an admin to access an admin-only admin-domain route', function () {
+    $admin = User::factory()->admin()->create();
+
+    $response = $this->actingAs($admin)->get('http://admin.localhost/dba/trimanalytics');
+
+    $response->assertOk();
+});
+
+it('calls the next middleware when the user is allowed() the given role', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('allowed')->with('teacher')->andReturn(true);
+
+    $request = Mockery::mock(Request::class)->makePartial();
+    $request->shouldReceive('user')->andReturn($user);
+
+    $middleware = new Role;
+
+    $called = false;
+    $next = new Symfony\Component\HttpFoundation\Response('next-response');
+    $response = $middleware->handle($request, function ($req) use (&$called, $next) {
+        $called = true;
+
+        return $next;
+    }, 'teacher');
+
+    expect($called)->toBeTrue();
+    expect($response)->toBe($next);
+});
+
+it('redirects to / and flashes an error when the user is not allowed() the given role', function () {
+    $user = Mockery::mock(User::class)->makePartial();
+    $user->shouldReceive('allowed')->with('admin')->andReturn(false);
+
+    $request = Mockery::mock(Request::class)->makePartial();
+    $request->shouldReceive('user')->andReturn($user);
+
+    $middleware = new Role;
+
+    $called = false;
+    $response = $middleware->handle($request, function () use (&$called) {
+        $called = true;
+    }, 'admin');
+
+    expect($called)->toBeFalse();
+    expect($response->getTargetUrl())->toContain('/');
+    expect(session('flash_notification'))->not->toBeNull();
+});

--- a/tests/Feature/Auth/SetBrowserLocaleMiddlewareTest.php
+++ b/tests/Feature/Auth/SetBrowserLocaleMiddlewareTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Http\Middleware\SetBrowserLocale;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\App;
+use Symfony\Component\HttpFoundation\Response;
+
+beforeEach(function () {
+    $this->originalLocale = App::getLocale();
+    $this->hadHeader = array_key_exists('HTTP_ACCEPT_LANGUAGE', $_SERVER);
+    $this->originalHeader = $_SERVER['HTTP_ACCEPT_LANGUAGE'] ?? null;
+});
+
+afterEach(function () {
+    App::setLocale($this->originalLocale);
+
+    if ($this->hadHeader) {
+        $_SERVER['HTTP_ACCEPT_LANGUAGE'] = $this->originalHeader;
+    } else {
+        unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    }
+});
+
+it('sets the app locale from the first two letters of Accept-Language', function () {
+    $_SERVER['HTTP_ACCEPT_LANGUAGE'] = 'de-DE,de;q=0.9,en;q=0.8';
+    App::setLocale('en');
+
+    $middleware = new SetBrowserLocale;
+    $request = Request::create('http://localhost/');
+
+    $response = $middleware->handle($request, fn ($req) => new Response('next-called'));
+
+    expect($response->getContent())->toBe('next-called');
+    expect(App::getLocale())->toBe('de');
+});
+
+it('leaves the current locale untouched when no Accept-Language header is present', function () {
+    unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+    App::setLocale('en');
+
+    $middleware = new SetBrowserLocale;
+    $request = Request::create('http://localhost/');
+
+    $middleware->handle($request, fn ($req) => new Response('ok'));
+
+    expect(App::getLocale())->toBe('en');
+});
+
+it('always calls the next middleware and forwards its response', function () {
+    unset($_SERVER['HTTP_ACCEPT_LANGUAGE']);
+
+    $middleware = new SetBrowserLocale;
+    $request = Request::create('http://localhost/');
+
+    $response = $middleware->handle($request, fn ($req) => new Response('the-next-response'));
+
+    expect($response->getContent())->toBe('the-next-response');
+});

--- a/tests/Feature/Auth/SubdomainMiddlewareTest.php
+++ b/tests/Feature/Auth/SubdomainMiddlewareTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Http\Middleware\Subdomain;
+use Illuminate\Http\Request;
+
+it('detects no subdomain for the main domain host', function () {
+    $middleware = new Subdomain;
+    $request = Request::create('http://localhost/');
+
+    expect($middleware->checkSubdomain($request))->toBeNull();
+});
+
+it('detects no subdomain for the admin domain host', function () {
+    $middleware = new Subdomain;
+    $request = Request::create('http://admin.localhost/');
+
+    expect($middleware->checkSubdomain($request))->toBeNull();
+});
+
+it('detects a hub subdomain for a genuine hub host', function () {
+    $middleware = new Subdomain;
+    $request = Request::create('http://myhub.localhost/');
+
+    expect($middleware->checkSubdomain($request))->toBe('myhub');
+});
+
+it('leaves the main domain request unaffected end-to-end', function () {
+    $response = $this->get('http://localhost/');
+
+    $response->assertOk();
+    expect(config('app.url'))->toBe('http://localhost');
+});
+
+it('leaves the admin domain request unaffected (no hub context)', function () {
+    // Unauthenticated request to a protected admin route: routing/middleware
+    // still runs correctly and simply redirects to login, proving the
+    // Subdomain middleware did not misidentify "admin.localhost" as a hub.
+    $response = $this->get('http://admin.localhost/password');
+
+    $response->assertRedirect('http://admin.localhost/login');
+});

--- a/tests/Feature/Hub/AdminControllers/HubControllerDestroyTest.php
+++ b/tests/Feature/Hub/AdminControllers/HubControllerDestroyTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+
+function adminControllersTenantDbExists(string $name): bool
+{
+    return DB::connection('mysql')->selectOne(
+        'SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = ?',
+        [$name]
+    ) !== null;
+}
+
+/**
+ * ProvisionsHubs::createTeacher() inserts via User::create(), and
+ * `email_verified_at` is deliberately not mass-assignable, so it is silently
+ * dropped there, leaving the teacher unverified. That's invisible on
+ * hub-domain requests but the admin domain's `verified` middleware enforces
+ * it for real, so any test authenticating as a createTeacher()-made user
+ * against admin.localhost needs it marked verified first.
+ */
+function destroyTestVerifyEmail(User $user): User
+{
+    $user->forceFill(['email_verified_at' => now()])->save();
+
+    return $user;
+}
+
+// --- destroy: real provisioning + real drop ---
+
+test('owner teacher can destroy their hub and its tenant database is dropped', function () {
+    $teacher = destroyTestVerifyEmail($this->createTeacher());
+    $hub = $this->createHub($teacher);
+
+    $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+    expect(adminControllersTenantDbExists($dbName))->toBeTrue();
+
+    $response = $this->actingAs($teacher)->delete("http://admin.localhost/hubs/{$hub->id}");
+
+    $response->assertOk();
+    $response->assertJson(['destroyed' => true]);
+
+    expect(Hub::find($hub->id))->toBeNull();
+    expect(adminControllersTenantDbExists($dbName))->toBeFalse();
+});
+
+test('admin can destroy any hub and its tenant database is dropped', function () {
+    $teacher = $this->createTeacher();
+    $hub = $this->createHub($teacher);
+    $admin = User::factory()->admin()->create();
+
+    $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+
+    $response = $this->actingAs($admin)->delete("http://admin.localhost/hubs/{$hub->id}");
+
+    $response->assertOk();
+    $response->assertJson(['destroyed' => true]);
+
+    expect(Hub::find($hub->id))->toBeNull();
+    expect(adminControllersTenantDbExists($dbName))->toBeFalse();
+});
+
+test('destroying a hub also drops its dedicated tenant db user', function () {
+    $teacher = destroyTestVerifyEmail($this->createTeacher());
+    $hub = $this->createHub($teacher);
+    $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+
+    $this->actingAs($teacher)->delete("http://admin.localhost/hubs/{$hub->id}");
+
+    $userExists = DB::connection('mysql')->selectOne(
+        "SELECT User FROM mysql.user WHERE User = ?",
+        [$dbName]
+    );
+
+    expect($userExists)->toBeNull();
+});

--- a/tests/Feature/Hub/AdminControllers/HubControllerIndexAndShowTest.php
+++ b/tests/Feature/Hub/AdminControllers/HubControllerIndexAndShowTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+
+/**
+ * HubController@index and @show render Livewire components (`hub.index`,
+ * `hub.show`) that read real per-hub computed attributes (`$hub->admin`,
+ * `->activated`, `->readonly`, `->hasWorkingUser`, table listings) which open
+ * an actual connection to that hub's tenant database. So, unlike pure
+ * listing/validation tests, any scenario that renders a non-empty hub row
+ * needs a *really* provisioned hub (createHub()), which is why these live
+ * here rather than in Feature/Admin.
+ */
+
+/**
+ * ProvisionsHubs::createTeacher() inserts the row via User::create(), and
+ * `email_verified_at` is intentionally not mass-assignable (see
+ * App\Models\User::$fillable / tests/README.md rule #1) so it is silently
+ * dropped, leaving the teacher unverified. That's invisible for hub-domain
+ * requests (User::hasVerifiedEmail() short-circuits to true there), but the
+ * admin domain's `verified` middleware does check it for real, so any test
+ * that authenticates *as* a createTeacher()-made user against admin.localhost
+ * needs it marked verified first.
+ */
+function indexShowTestVerifyEmail(User $user): User
+{
+    $user->forceFill(['email_verified_at' => now()])->save();
+
+    return $user;
+}
+
+test('teacher only sees their own hubs', function () {
+    $teacher = indexShowTestVerifyEmail($this->createTeacher());
+    $otherTeacher = $this->createTeacher();
+
+    $ownHub = $this->createHub($teacher, ['name' => 'ownhub'.uniqid()], 'all_empty');
+    $this->createHub($otherTeacher, ['name' => 'otherhub'.uniqid()], 'all_empty');
+
+    $this->actingAs($teacher)
+        ->get('http://admin.localhost/')
+        ->assertOk()
+        ->assertSee($ownHub->name);
+});
+
+test('admin sees all hubs', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $teacher = $this->createTeacher();
+
+    $hubA = $this->createHub($teacher, ['name' => 'firsthub'.uniqid()], 'all_empty');
+    $hubB = $this->createHub($teacher, ['name' => 'secondhub'.uniqid()], 'all_empty');
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/hubs')
+        ->assertOk()
+        ->assertSee($hubA->name)
+        ->assertSee($hubB->name);
+});
+
+test('hub listing can be searched by name', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $teacher = $this->createTeacher();
+
+    $match = $this->createHub($teacher, ['name' => 'findmehub'], 'all_empty');
+    $noMatch = $this->createHub($teacher, ['name' => 'unrelated'], 'all_empty');
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/hubs?search=findme')
+        ->assertOk()
+        ->assertSee($match->name)
+        ->assertDontSee($noMatch->name);
+});
+
+test('hub listing is paginated at 10 per page', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $teacher = $this->createTeacher();
+
+    $hubs = collect(range(1, 11))->map(
+        fn ($i) => $this->createHub($teacher, ['name' => 'pagehub'.$i], 'all_empty')
+    );
+
+    $firstPage = $this->actingAs($admin)->get('http://admin.localhost/hubs');
+    $firstPage->assertOk();
+    foreach ($hubs->take(10) as $hub) {
+        $firstPage->assertSee($hub->name);
+    }
+    $firstPage->assertDontSee($hubs->last()->name);
+
+    $this->actingAs($admin)
+        ->get('http://admin.localhost/hubs?page=2')
+        ->assertOk()
+        ->assertSee($hubs->last()->name);
+})->group('slow');
+
+// --- show, against a real provisioned tenant ---
+
+test('teacher can view their own hub', function () {
+    $teacher = indexShowTestVerifyEmail($this->createTeacher());
+    $hub = $this->createHub($teacher, creating: 'users');
+
+    $this->actingAs($teacher)
+        ->get("http://admin.localhost/hubs/{$hub->id}")
+        ->assertOk();
+});
+
+test('admin can view any hub', function () {
+    $admin = User::factory()->admin()->create(['hub_default_generation' => 1]);
+    $teacher = $this->createTeacher();
+    $hub = $this->createHub($teacher, creating: 'users');
+
+    $this->actingAs($admin)
+        ->get("http://admin.localhost/hubs/{$hub->id}")
+        ->assertOk()
+        ->assertSee('users');
+});

--- a/tests/Feature/Hub/AdminControllers/HubControllerStoreTest.php
+++ b/tests/Feature/Hub/AdminControllers/HubControllerStoreTest.php
@@ -1,0 +1,161 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Storage;
+
+/**
+ * HubController@store is the crown-jewel provisioning path: it creates the
+ * `hubs` row, a real tenant MySQL database + DB user (GRANT), hydrates the
+ * tenant schema, and updates the tenant `admin` user. These tests exercise
+ * the real thing end-to-end (no mocking), so they must live here (DatabaseMigrations
+ * + ProvisionsHubs, no wrapping transaction).
+ */
+function tenantDatabaseExists(string $name): bool
+{
+    return DB::connection('mysql')->selectOne(
+        'SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = ?',
+        [$name]
+    ) !== null;
+}
+
+test('a teacher creating their own hub gets a fully provisioned, auto-activated tenant', function () {
+    // hub_default_creating must be 'users' (the real column default) so the
+    // tenant `users` table is seeded and an `admin` user actually exists for
+    // HubController@store to update; the ProvisionsHubs/UserFactory default
+    // of 'all_empty' only migrates empty tables and would leave the
+    // controller updating a null $admin (a pre-existing app quirk, not
+    // something this test suite should paper over).
+    $teacher = $this->createTeacher(['hub_default_creating' => 'users']);
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'selfmadehub',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Hub Admin',
+        'email' => 'hubadmin@example.test',
+        'bio' => 'Hello there',
+        'birthday' => '2000-01-01',
+        'city' => 'Leipzig',
+        'country' => 'Germany',
+        'centimeters' => '180',
+    ]);
+
+    $response->assertRedirect('/');
+
+    $hub = Hub::where('name', 'selfmadehub')->firstOrFail();
+    expect((int) $hub->teacher_id)->toBe($teacher->id);
+    expect($hub->password)->not->toBeEmpty();
+
+    $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+    expect(tenantDatabaseExists($dbName))->toBeTrue();
+
+    $admin = $this->withinHub($hub, fn () => User::where('username', 'admin')->first());
+
+    expect($admin)->not->toBeNull();
+    expect($admin->name)->toBe('Hub Admin');
+    expect($admin->email)->toBe('hubadmin@example.test');
+    expect($admin->bio)->toBe('Hello there');
+    expect($admin->city)->toBe('Leipzig');
+    expect((bool) $admin->is_active)->toBeTrue(); // self-created hubs are trusted immediately
+});
+
+test('store provisions the avatar upload into the tenant admin user', function () {
+    Storage::fake('local');
+
+    $teacher = $this->createTeacher(['hub_default_creating' => 'users']);
+
+    $avatar = UploadedFile::fake()->image('avatar.jpg', 300, 300);
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'avatarhub',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Hub Admin',
+        'email' => 'hubadmin@example.test',
+        'avatar' => $avatar,
+    ]);
+
+    $response->assertRedirect('/');
+
+    $hub = Hub::where('name', 'avatarhub')->firstOrFail();
+    $admin = $this->withinHub($hub, fn () => User::where('username', 'admin')->first());
+
+    expect($admin->avatar)->toStartWith('avatars/');
+    expect($admin->avatar)->toEndWith('.webp');
+    Storage::disk('local')->assertExists($admin->avatar);
+});
+
+test('a hub created by someone else for a teacher is not auto-activated', function () {
+    $teacher = $this->createTeacher(['hub_default_creating' => 'users']);
+
+    $response = $this->withSession(['register_hub_name' => 'guestmadehub'])
+        ->post('http://admin.localhost/hubs', [
+            'hub' => 'guestmadehub',
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'teacher' => $teacher->username,
+            'username' => 'admin',
+            'name' => 'Hub Admin',
+            'email' => 'hubadmin@example.test',
+        ]);
+
+    $hub = Hub::where('name', 'guestmadehub')->firstOrFail();
+    expect((int) $hub->teacher_id)->toBe($teacher->id);
+
+    $response->assertRedirect('http://guestmadehub.localhost');
+
+    $admin = $this->withinHub($hub, fn () => User::where('username', 'admin')->first());
+    expect((bool) $admin->is_active)->toBeFalse(); // must be activated by the teacher
+});
+
+test('guest registration is rejected when the hub name was not pre-issued in the session', function () {
+    $teacher = $this->createTeacher(['hub_default_creating' => 'users']);
+
+    $response = $this->withSession(['register_hub_name' => 'expectedname'])
+        ->post('http://admin.localhost/hubs', [
+            'hub' => 'differentname',
+            'password' => 'secret123',
+            'password_confirmation' => 'secret123',
+            'teacher' => $teacher->username,
+            'username' => 'admin',
+            'name' => 'Hub Admin',
+            'email' => 'hubadmin@example.test',
+        ]);
+
+    $response->assertSessionHasErrors('hub');
+    expect(Hub::where('name', 'differentname')->exists())->toBeFalse();
+});
+
+test('the tenant grant actually works: the tenant db user can connect and query its own database', function () {
+    $teacher = $this->createTeacher(['hub_default_creating' => 'users']);
+
+    $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'grantcheckhub',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Hub Admin',
+        'email' => 'hubadmin@example.test',
+    ]);
+
+    $hub = Hub::where('name', 'grantcheckhub')->firstOrFail();
+    $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+
+    $pdo = new PDO(
+        'mysql:host='.config('database.connections.mysql.host').';dbname='.$dbName,
+        $dbName,
+        $hub->password
+    );
+
+    $tables = $pdo->query('SHOW TABLES')->fetchAll(PDO::FETCH_COLUMN);
+
+    expect($tables)->toContain('users');
+});

--- a/tests/Feature/Hub/AdminControllers/HubControllerStoreTest.php
+++ b/tests/Feature/Hub/AdminControllers/HubControllerStoreTest.php
@@ -64,6 +64,35 @@ test('a teacher creating their own hub gets a fully provisioned, auto-activated 
     expect((bool) $admin->is_active)->toBeTrue(); // self-created hubs are trusted immediately
 });
 
+test('a teacher whose default is all_empty still gets a working dba admin user', function () {
+    $teacher = $this->createTeacher(['hub_default_creating' => 'all_empty']);
+
+    $response = $this->actingAs($teacher)->post('http://admin.localhost/hubs', [
+        'hub' => 'emptyhub',
+        'password' => 'secret123',
+        'password_confirmation' => 'secret123',
+        'teacher' => $teacher->username,
+        'username' => 'admin',
+        'name' => 'Hub Admin',
+        'email' => 'hubadmin@example.test',
+    ]);
+
+    $response->assertRedirect('/');
+
+    $hub = Hub::where('name', 'emptyhub')->firstOrFail();
+    expect(tenantDatabaseExists(env('DB_DATABASE', 'testing').'_'.$hub->id))->toBeTrue();
+
+    // The all_empty creating mode migrates empty tables and seeds no admin, so
+    // HubController@store must create one itself (previously it fatally called
+    // ->update() on null).
+    $admin = $this->withinHub($hub, fn () => User::where('username', 'admin')->first());
+
+    expect($admin)->not->toBeNull()
+        ->and($admin->name)->toBe('Hub Admin')
+        ->and($admin->role)->toBe('dba')
+        ->and((bool) $admin->is_active)->toBeTrue();
+});
+
 test('store provisions the avatar upload into the tenant admin user', function () {
     Storage::fake('local');
 

--- a/tests/Feature/Hub/Controllers/AdControllerTest.php
+++ b/tests/Feature/Hub/Controllers/AdControllerTest.php
@@ -1,0 +1,149 @@
+<?php
+
+use App\Models\Ad;
+use App\Models\User;
+
+test('guest cannot view the ads index', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->onHub($hub)->get($this->hubUrl($hub, '/ads'))->assertRedirect();
+});
+
+test('authenticated user can view the ads index', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $ad = Ad::factory()->create(['name' => 'Summer Sale']);
+
+        return compact('user', 'ad');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->get($this->hubUrl($hub, '/ads'))
+        ->assertOk()
+        ->assertSee('Summer Sale');
+});
+
+test('authenticated user can view the create ad form', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/ads/create'))
+        ->assertOk();
+});
+
+test('authenticated user can create an ad', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $response = $this->onHub($hub)->actingAs($user)
+        ->post($this->hubUrl($hub, '/ads'), [
+            'name' => 'Winter Sale',
+            'type' => 'banner',
+            'priority' => 1,
+            'url' => '/noad',
+            'img' => '/img/ad/winter.jpg',
+            'query' => 'SELECT id FROM users WHERE id=$user',
+        ]);
+
+    $response->assertRedirect('/ads');
+
+    $this->withinHub($hub, function () {
+        expect(Ad::where('name', 'Winter Sale')->exists())->toBeTrue();
+    });
+});
+
+test('creating an ad validates required fields', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->post($this->hubUrl($hub, '/ads'), [])
+        ->assertSessionHasErrors(['type', 'url', 'img', 'query']);
+});
+
+test('authenticated user can view the edit ad form', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $ad = Ad::factory()->create();
+
+        return compact('user', 'ad');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->get($this->hubUrl($hub, '/ads/'.$ids['ad']->id.'/edit'))
+        ->assertOk();
+});
+
+test('authenticated user can update an ad', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $ad = Ad::factory()->create(['name' => 'Old Name']);
+
+        return compact('user', 'ad');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->put($this->hubUrl($hub, '/ads/'.$ids['ad']->id), [
+            'name' => 'New Name',
+            'type' => 'banner',
+            'priority' => 2,
+            'url' => '/noad',
+            'img' => '/img/ad/winter.jpg',
+            'query' => 'SELECT id FROM users WHERE id=$user',
+        ])
+        ->assertRedirect('/ads');
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect($ids['ad']->fresh()->name)->toBe('New Name');
+    });
+});
+
+test('authenticated user can delete an ad via the custom destroy route', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $ad = Ad::factory()->create();
+
+        return compact('user', 'ad');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->delete($this->hubUrl($hub, '/api/ads/'.$ids['ad']->id))
+        ->assertOk()
+        ->assertJsonStructure(['success']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Ad::find($ids['ad']->id))->toBeNull();
+    });
+});
+
+test('guest cannot delete an ad', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $adId = $this->withinHub($hub, fn () => Ad::factory()->create()->id);
+
+    $this->onHub($hub)
+        ->delete($this->hubUrl($hub, '/api/ads/'.$adId))
+        ->assertRedirect();
+
+    $this->withinHub($hub, function () use ($adId) {
+        expect(Ad::find($adId))->not->toBeNull();
+    });
+});
+
+test('deleting a non-existent ad returns a 404', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->delete($this->hubUrl($hub, '/api/ads/999999'))
+        ->assertNotFound();
+});

--- a/tests/Feature/Hub/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Hub/Controllers/CommentControllerTest.php
@@ -86,24 +86,41 @@ test('guest cannot delete a comment', function () {
     });
 });
 
-// Note: CommentController@destroy has no ownership check (the
-// `$this->authorize(...)` call is commented out in app code), so any
-// authenticated hub user can currently delete any other user's comment.
-// This documents the actual (unguarded) behaviour rather than the ideal one;
-// app code was left untouched per instructions.
-test('authenticated user can currently delete another users comment (no ownership check enforced)', function () {
+test('a user who is neither the author nor the photo owner cannot delete a comment', function () {
     $hub = $this->createHub(creating: 'all_empty');
 
     $ids = $this->withinHub($hub, function () {
         $owner = User::factory()->create();
-        $other = User::factory()->create();
+        $author = User::factory()->create();
+        $stranger = User::factory()->create();
         $photo = Photo::factory()->create(['user_id' => $owner->id]);
-        $comment = Comment::factory()->create(['user_id' => $owner->id, 'photo_id' => $photo->id]);
+        $comment = Comment::factory()->create(['user_id' => $author->id, 'photo_id' => $photo->id]);
 
-        return compact('other', 'comment');
+        return compact('stranger', 'comment');
     });
 
-    $this->onHub($hub)->actingAs($ids['other'])
+    $this->onHub($hub)->actingAs($ids['stranger'])
+        ->delete($this->hubUrl($hub, '/api/me/comment/'.$ids['comment']->id))
+        ->assertForbidden();
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Comment::find($ids['comment']->id))->not->toBeNull();
+    });
+});
+
+test('the photo owner can delete a comment left on their photo by someone else', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $author = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+        $comment = Comment::factory()->create(['user_id' => $author->id, 'photo_id' => $photo->id]);
+
+        return compact('owner', 'comment');
+    });
+
+    $this->onHub($hub)->actingAs($ids['owner'])
         ->delete($this->hubUrl($hub, '/api/me/comment/'.$ids['comment']->id))
         ->assertOk()
         ->assertJson(['success' => 'true']);

--- a/tests/Feature/Hub/Controllers/CommentControllerTest.php
+++ b/tests/Feature/Hub/Controllers/CommentControllerTest.php
@@ -1,0 +1,114 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Photo;
+use App\Models\User;
+
+test('guest cannot post a comment', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $photoId = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+
+        return Photo::factory()->create(['user_id' => $user->id])->id;
+    });
+
+    $this->onHub($hub)
+        ->post($this->hubUrl($hub, '/api/me/comment/'.$photoId), ['comment' => 'hi'])
+        ->assertRedirect();
+});
+
+test('authenticated user can post a comment on a photo', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $commenter = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+
+        return compact('commenter', 'photo');
+    });
+
+    $response = $this->onHub($hub)->actingAs($ids['commenter'])
+        ->post($this->hubUrl($hub, '/api/me/comment/'.$ids['photo']->id), [
+            'comment' => 'Nice #photo!',
+        ]);
+
+    $response->assertCreated()
+        ->assertJsonPath('data.owner.username', $ids['commenter']->username);
+
+    $this->withinHub($hub, function () use ($ids) {
+        $comment = Comment::where('photo_id', $ids['photo']->id)->first();
+
+        expect($comment)->not->toBeNull();
+        expect($comment->body)->toBe('Nice #photo!');
+        expect($comment->user_id)->toBe($ids['commenter']->id);
+    });
+});
+
+test('authenticated user can delete a comment', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+        $comment = Comment::factory()->create(['user_id' => $user->id, 'photo_id' => $photo->id]);
+
+        return compact('user', 'comment');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->delete($this->hubUrl($hub, '/api/me/comment/'.$ids['comment']->id))
+        ->assertOk()
+        ->assertJson(['success' => 'true']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Comment::find($ids['comment']->id))->toBeNull();
+    });
+});
+
+test('guest cannot delete a comment', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $commentId = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+
+        return Comment::factory()->create(['user_id' => $user->id, 'photo_id' => $photo->id])->id;
+    });
+
+    $this->onHub($hub)
+        ->delete($this->hubUrl($hub, '/api/me/comment/'.$commentId))
+        ->assertRedirect();
+
+    $this->withinHub($hub, function () use ($commentId) {
+        expect(Comment::find($commentId))->not->toBeNull();
+    });
+});
+
+// Note: CommentController@destroy has no ownership check (the
+// `$this->authorize(...)` call is commented out in app code), so any
+// authenticated hub user can currently delete any other user's comment.
+// This documents the actual (unguarded) behaviour rather than the ideal one;
+// app code was left untouched per instructions.
+test('authenticated user can currently delete another users comment (no ownership check enforced)', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $other = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+        $comment = Comment::factory()->create(['user_id' => $owner->id, 'photo_id' => $photo->id]);
+
+        return compact('other', 'comment');
+    });
+
+    $this->onHub($hub)->actingAs($ids['other'])
+        ->delete($this->hubUrl($hub, '/api/me/comment/'.$ids['comment']->id))
+        ->assertOk()
+        ->assertJson(['success' => 'true']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Comment::find($ids['comment']->id))->toBeNull();
+    });
+});

--- a/tests/Feature/Hub/Controllers/FollowControllerTest.php
+++ b/tests/Feature/Hub/Controllers/FollowControllerTest.php
@@ -1,0 +1,115 @@
+<?php
+
+use App\Models\User;
+
+test('guest cannot follow a user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $target = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)
+        ->post($this->hubUrl($hub, 'api/me/follow/'.$target->username))
+        ->assertRedirect();
+});
+
+test('authenticated user can follow another user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $follower = User::factory()->create();
+        $target = User::factory()->create();
+
+        return compact('follower', 'target');
+    });
+
+    $this->onHub($hub)->actingAs($ids['follower'])
+        ->post($this->hubUrl($hub, 'api/me/follow/'.$ids['target']->username))
+        ->assertOk()
+        ->assertJson(['follow' => 'true']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect($ids['follower']->fresh()->following()->pluck('users.id'))->toContain($ids['target']->id);
+        expect($ids['target']->fresh()->followers()->pluck('users.id'))->toContain($ids['follower']->id);
+    });
+});
+
+test('authenticated user can unfollow a user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $follower = User::factory()->create();
+        $target = User::factory()->create();
+        $follower->following()->attach($target);
+
+        return compact('follower', 'target');
+    });
+
+    $this->onHub($hub)->actingAs($ids['follower'])
+        ->delete($this->hubUrl($hub, 'api/me/follow/'.$ids['target']->username))
+        ->assertOk()
+        ->assertJson(['follow' => 'false']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect($ids['follower']->fresh()->following()->pluck('users.id'))->not->toContain($ids['target']->id);
+    });
+});
+
+test('guest cannot unfollow a user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $follower = User::factory()->create();
+        $target = User::factory()->create();
+        $follower->following()->attach($target);
+
+        return compact('follower', 'target');
+    });
+
+    $this->onHub($hub)
+        ->delete($this->hubUrl($hub, 'api/me/follow/'.$ids['target']->username))
+        ->assertRedirect();
+});
+
+test('followers page lists the users following a given user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $follower = User::factory()->create();
+        $target = User::factory()->create();
+        $follower->following()->attach($target);
+
+        return compact('follower', 'target');
+    });
+
+    $this->onHub($hub)->actingAs($ids['follower'])
+        ->get($this->hubUrl($hub, $ids['target']->username.'/followers'))
+        ->assertOk()
+        ->assertSee($ids['follower']->username);
+});
+
+test('following page lists the users a given user follows', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $follower = User::factory()->create();
+        $target = User::factory()->create();
+        $follower->following()->attach($target);
+
+        return compact('follower', 'target');
+    });
+
+    $this->onHub($hub)->actingAs($ids['follower'])
+        ->get($this->hubUrl($hub, $ids['follower']->username.'/following'))
+        ->assertOk()
+        ->assertSee($ids['target']->username);
+});
+
+test('guest cannot view the followers page', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $target = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)
+        ->get($this->hubUrl($hub, $target->username.'/followers'))
+        ->assertRedirect();
+});

--- a/tests/Feature/Hub/Controllers/LikeControllerTest.php
+++ b/tests/Feature/Hub/Controllers/LikeControllerTest.php
@@ -1,0 +1,75 @@
+<?php
+
+use App\Models\Like;
+use App\Models\Photo;
+use App\Models\User;
+
+test('guest cannot like a photo', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $photoId = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+
+        return Photo::factory()->create(['user_id' => $user->id])->id;
+    });
+
+    $this->onHub($hub)
+        ->post($this->hubUrl($hub, '/api/me/like/'.$photoId))
+        ->assertRedirect();
+});
+
+test('liking a photo toggles the like on and off', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+
+        return compact('user', 'photo');
+    });
+
+    // First request: like.
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->post($this->hubUrl($hub, '/api/me/like/'.$ids['photo']->id))
+        ->assertOk()
+        ->assertJson(['like' => 'true']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Like::where('photo_id', $ids['photo']->id)->where('user_id', $ids['user']->id)->exists())->toBeTrue();
+    });
+
+    // Second request: unlike.
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->post($this->hubUrl($hub, '/api/me/like/'.$ids['photo']->id))
+        ->assertOk()
+        ->assertJson(['like' => 'false']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Like::where('photo_id', $ids['photo']->id)->where('user_id', $ids['user']->id)->exists())->toBeFalse();
+    });
+});
+
+test('two different users can independently like the same photo', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $liker1 = User::factory()->create();
+        $liker2 = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+
+        return compact('liker1', 'liker2', 'photo');
+    });
+
+    $this->onHub($hub)->actingAs($ids['liker1'])
+        ->post($this->hubUrl($hub, '/api/me/like/'.$ids['photo']->id))
+        ->assertJson(['like' => 'true']);
+
+    $this->onHub($hub)->actingAs($ids['liker2'])
+        ->post($this->hubUrl($hub, '/api/me/like/'.$ids['photo']->id))
+        ->assertJson(['like' => 'true']);
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(Like::where('photo_id', $ids['photo']->id)->count())->toBe(2);
+    });
+});

--- a/tests/Feature/Hub/Controllers/PhotoControllerTest.php
+++ b/tests/Feature/Hub/Controllers/PhotoControllerTest.php
@@ -1,0 +1,209 @@
+<?php
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\Storage;
+
+test('guest is redirected away from the feed', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->onHub($hub)->get($this->hubUrl($hub, '/'))->assertRedirect();
+});
+
+test('authenticated user sees an empty feed', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/'))
+        ->assertOk()
+        ->assertSee('Nothing to show.');
+});
+
+test('feed lists photos sorted by date by default', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    [$user, $photo] = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+
+        return [$user, $photo];
+    });
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/'))
+        ->assertOk()
+        ->assertSee($photo->url, false);
+});
+
+test('feed only shows photos of followed users when the follows table exists', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $me = User::factory()->create();
+        $stranger = User::factory()->create();
+        $ownPhoto = Photo::factory()->create(['user_id' => $me->id]);
+        $strangerPhoto = Photo::factory()->create(['user_id' => $stranger->id]);
+
+        return compact('me', 'ownPhoto', 'strangerPhoto');
+    });
+
+    $this->onHub($hub)->actingAs($ids['me'])
+        ->get($this->hubUrl($hub, '/'))
+        ->assertOk()
+        ->assertSee($ids['ownPhoto']->url, false)
+        ->assertDontSee($ids['strangerPhoto']->url, false);
+});
+
+test('feed can be sorted by best and stores the choice in the session', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        Photo::factory()->create(['user_id' => $user->id]);
+
+        return $user;
+    });
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/?sort=best'))
+        ->assertOk()
+        ->assertSessionHas('sort_feed', 'best');
+});
+
+test('feed can be sorted with custom weights', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        Photo::factory()->create(['user_id' => $user->id]);
+
+        return $user;
+    });
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/?sort=custom&weights[like_weight]=5'))
+        ->assertOk()
+        ->assertSessionHas('sort_feed', 'custom')
+        ->assertSessionHas('sort_feed_weights.like_weight', '5');
+});
+
+test('photosbytag filters photos by hashtag', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $tagged = Photo::factory()->create(['user_id' => $user->id, 'description' => 'Look at this #sunset']);
+        $untagged = Photo::factory()->create(['user_id' => $user->id, 'description' => 'no tags here']);
+
+        return compact('user', 'tagged', 'untagged');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->get($this->hubUrl($hub, '/tag/sunset'))
+        ->assertOk()
+        ->assertSee($ids['tagged']->url, false)
+        ->assertDontSee($ids['untagged']->url, false);
+});
+
+test('show renders a single photo and records an analytic visit', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+
+        return compact('user', 'photo');
+    });
+
+    $this->onHub($hub)->actingAs($ids['user'])
+        ->get($this->hubUrl($hub, '/p/'.$ids['photo']->id))
+        ->assertOk();
+
+    $this->withinHub($hub, function () use ($ids) {
+        expect(\App\Models\Analytic::where('photo_id', $ids['photo']->id)->where('user_id', $ids['user']->id)->exists())->toBeTrue();
+    });
+});
+
+test('create renders the upload form', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->get($this->hubUrl($hub, '/upload'))
+        ->assertOk()
+        ->assertSee('Upload new Photo');
+});
+
+test('guest cannot access the upload form', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->onHub($hub)->get($this->hubUrl($hub, '/upload'))->assertRedirect();
+});
+
+test('store uploads a photo and parses hashtags from the description', function () {
+    Storage::fake('local');
+
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $file = UploadedFile::fake()->image('photo.jpg', 200, 200);
+
+    $response = $this->onHub($hub)->actingAs($user)
+        ->post($this->hubUrl($hub, '/upload'), [
+            'photo' => $file,
+            'description' => 'Great day at the #beach with #Friends',
+        ]);
+
+    $response->assertRedirect();
+
+    $this->withinHub($hub, function () use ($user) {
+        $photo = Photo::where('user_id', $user->id)->firstOrFail();
+
+        expect($photo->description)->toBe('Great day at the #beach with #Friends');
+        expect(Storage::disk('local')->exists($photo->url))->toBeTrue();
+
+        $tagNames = $photo->tags()->pluck('name')->sort()->values()->all();
+        expect($tagNames)->toBe(['beach', 'friends']);
+    });
+});
+
+test('store validates required fields', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+    $user = $this->withinHub($hub, fn () => User::factory()->create());
+
+    $this->onHub($hub)->actingAs($user)
+        ->post($this->hubUrl($hub, '/upload'), [])
+        ->assertSessionHasErrors(['photo', 'description']);
+});
+
+test('guest cannot store a photo', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->onHub($hub)->post($this->hubUrl($hub, '/upload'), [
+        'description' => 'nope',
+    ])->assertRedirect();
+});
+
+test('hub-only routes are blocked when accessed through the admin domain', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $ids = $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $user->id]);
+
+        return compact('user', 'photo');
+    });
+
+    // The hub route group's domain pattern ("{subdomain}.localhost") also
+    // technically matches "admin.localhost" - IsHubMiddleware explicitly
+    // rejects that case. We use the like-route here (rather than /upload)
+    // because single-segment hub paths collide with a catch-all "/{user}"
+    // route that already exists on the literal admin domain.
+    $this->actingAs($ids['user']);
+    $_SERVER['HTTP_HOST'] = config('app.domain_admin');
+    app()->forgetInstance('requestHub');
+
+    $this->withServerVariables(['HTTP_HOST' => config('app.domain_admin')])
+        ->post('http://'.config('app.domain_admin').'/api/me/like/'.$ids['photo']->id)
+        ->assertForbidden();
+});

--- a/tests/Feature/Hub/Livewire/AdIndexTest.php
+++ b/tests/Feature/Hub/Livewire/AdIndexTest.php
@@ -1,0 +1,72 @@
+<?php
+
+use App\Livewire\Ad\Index;
+use App\Models\Ad;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\Ad\Index
+|--------------------------------------------------------------------------
+|
+| Ads only exist inside a tenant DB, so every test provisions a hub and
+| runs inside it via withinHub().
+*/
+
+test('lists the tenant ads, most recent first', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $viewer = User::factory()->dba()->create();
+        $this->actingAs($viewer);
+
+        $older = Ad::factory()->create(['name' => 'Older Ad', 'created_at' => now()->subDay()]);
+        $newer = Ad::factory()->create(['name' => 'Newer Ad', 'created_at' => now()]);
+
+        $html = Livewire::test(Index::class)->assertOk()->html();
+
+        expect(strpos($html, $newer->name))->toBeLessThan(strpos($html, $older->name));
+    });
+});
+
+test('deleteAd removes the ad when not read-only', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $viewer = User::factory()->dba()->create();
+        $this->actingAs($viewer);
+
+        $ad = Ad::factory()->create();
+
+        Livewire::test(Index::class)
+            ->call('deleteAd', $ad->id);
+
+        expect(Ad::find($ad->id))->toBeNull();
+    });
+});
+
+test('deleteAd is blocked in read-only mode', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    // Create the viewer and ad while the tenant DB is still writable...
+    [$viewerId, $adId] = $this->withinHub($hub, function () {
+        $viewer = User::factory()->dba()->create();
+        $ad = Ad::factory()->create();
+
+        return [$viewer->id, $ad->id];
+    });
+
+    // ...then flip the hub to read-only before exercising the component.
+    $hub->readonly = true;
+
+    $this->withinHub($hub, function () use ($viewerId, $adId) {
+        $this->actingAs(User::find($viewerId));
+
+        Livewire::test(Index::class)
+            ->call('deleteAd', $adId)
+            ->assertHasErrors('delete');
+
+        expect(Ad::find($adId))->not->toBeNull();
+    });
+});

--- a/tests/Feature/Hub/Livewire/FollowButtonTest.php
+++ b/tests/Feature/Hub/Livewire/FollowButtonTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Livewire\FollowButton;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\FollowButton
+|--------------------------------------------------------------------------
+|
+| follow()/unfollow() act on Auth::user()->following() against the tenant
+| `users`/`follows` tables, so every test provisions a hub and runs inside
+| it via withinHub().
+*/
+
+test('mount exposes the target username and initial following state', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $target = User::factory()->create(['username' => 'target1']);
+        $viewer = User::factory()->create();
+        $this->actingAs($viewer);
+
+        Livewire::test(FollowButton::class, ['username' => $target->username, 'isFollowing' => false])
+            ->assertOk()
+            ->assertSet('isFollowing', false)
+            ->assertSee(__('Follow'));
+    });
+});
+
+test('follow attaches the target user to the current user\'s following list', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $target = User::factory()->create(['username' => 'target2']);
+        $viewer = User::factory()->create();
+        $this->actingAs($viewer);
+
+        Livewire::test(FollowButton::class, ['username' => $target->username])
+            ->call('follow')
+            ->assertSet('isFollowing', true);
+
+        expect($viewer->following()->where('users.id', $target->id)->exists())->toBeTrue();
+    });
+});
+
+test('unfollow detaches the target user again', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $target = User::factory()->create(['username' => 'target3']);
+        $viewer = User::factory()->create();
+        $viewer->following()->attach($target);
+        $this->actingAs($viewer);
+
+        Livewire::test(FollowButton::class, ['username' => $target->username, 'isFollowing' => true])
+            ->call('unfollow')
+            ->assertSet('isFollowing', false);
+
+        expect($viewer->following()->where('users.id', $target->id)->exists())->toBeFalse();
+    });
+});

--- a/tests/Feature/Hub/Livewire/HubIndexTest.php
+++ b/tests/Feature/Hub/Livewire/HubIndexTest.php
@@ -1,0 +1,150 @@
+<?php
+
+use App\Livewire\Hub\Index;
+use App\Models\Hub;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\Hub\Index
+|--------------------------------------------------------------------------
+|
+| The component's view calls several tenant-DB-backed computed properties
+| ($hub->admin, ->activated, ->readonly, ->hasWorkingUser) for every listed
+| hub, so rendering it with any non-empty hub list requires a real
+| provisioned hub (ProvisionsHubs::createHub()) rather than a bare
+| Hub::factory() row. That's why this whole component lives under
+| tests/Feature/Hub/Livewire instead of tests/Feature/Livewire.
+*/
+
+test('admin sees every hub, regardless of owner', function () {
+    $admin = User::factory()->admin()->create();
+    $hubA = $this->createHub(creating: 'all_empty');
+    $hubB = $this->createHub(creating: 'all_empty');
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hubA])
+        ->assertOk()
+        ->assertSee($hubA->name)
+        ->assertSee($hubB->name);
+});
+
+test('teacher only sees their own hubs', function () {
+    $teacher = $this->createTeacher();
+    $otherTeacher = $this->createTeacher();
+
+    $ownHub = $this->createHub($teacher, creating: 'all_empty');
+    $otherHub = $this->createHub($otherTeacher, creating: 'all_empty');
+
+    Livewire::actingAs($teacher)
+        ->test(Index::class, ['hub' => $ownHub])
+        ->assertOk()
+        ->assertSee($ownHub->name)
+        ->assertDontSee($otherHub->name);
+});
+
+test('search filters the hub list by name', function () {
+    $admin = User::factory()->admin()->create();
+    $match = $this->createHub(creating: 'all_empty');
+    $noMatch = $this->createHub(creating: 'all_empty');
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $match])
+        ->set('search', $match->name)
+        ->assertSee($match->name)
+        ->assertDontSee($noMatch->name);
+});
+
+test('updating the search term resets pagination to page one', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('gotoPage', 2)
+        ->assertSet('paginators.page', 2)
+        ->set('search', 'some-other-term')
+        ->assertSet('paginators.page', 1);
+});
+
+test('setQueryLevel updates the hub row and the selected level', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty', attributes: ['query_level' => 'gui']);
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->assertSet('selectedQueryLevel', 'gui')
+        ->call('setQueryLevel', $hub->id, 'sql')
+        ->assertSet('selectedQueryLevel', 'sql');
+
+    expect($hub->fresh()->query_level)->toBe('sql');
+});
+
+test('setActivate creates and activates a dba account on the tenant database', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+
+    expect($hub->activated)->toBeFalsy();
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('setActivate', $hub->id, true);
+
+    expect($hub->fresh()->activated)->toBeTruthy();
+});
+
+test('setActivate can deactivate the tenant dba account again', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('setActivate', $hub->id, true);
+
+    expect($hub->fresh()->activated)->toBeTruthy();
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('setActivate', $hub->id, false);
+
+    expect($hub->fresh()->activated)->toBeFalsy();
+});
+
+test('setReadonly revokes write privileges on the tenant database', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+
+    expect($hub->readonly)->toBeFalse();
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('setReadonly', $hub->id, true);
+
+    expect($hub->fresh()->readonly)->toBeTrue();
+});
+
+test('fillTables reseeds a tenant table', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('fillTables', $hub->id, 'users');
+
+    $count = $this->withinHub($hub, fn () => \App\Models\User::count());
+
+    expect($count)->toBeGreaterThan(0);
+});
+
+test('destroy deletes the hub row and drops its tenant database', function () {
+    $admin = User::factory()->admin()->create();
+    $hub = $this->createHub(creating: 'all_empty');
+    $hubId = $hub->id;
+
+    Livewire::actingAs($admin)
+        ->test(Index::class, ['hub' => $hub])
+        ->call('destroy', $hubId);
+
+    expect(Hub::find($hubId))->toBeNull();
+});

--- a/tests/Feature/Hub/Livewire/HubShowTest.php
+++ b/tests/Feature/Hub/Livewire/HubShowTest.php
@@ -1,0 +1,77 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Livewire\Hub\Show;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\Hub\Show
+|--------------------------------------------------------------------------
+|
+| This component switches to the tenant DB itself via RequestHub::setHubDB(),
+| so it does not need withinHub()/onHub() — only a real provisioned hub.
+|
+| mount() leaves the default DB connection pointed at the tenant DB (by
+| design: this admin screen stays "on" the hub while managing it). In real
+| usage each Livewire action round-trips through a fresh HTTP request/
+| process, so the connection default always starts back at `mysql`. Our
+| single-process test run has no such reset between mount() and a
+| subsequent ->call(), and Livewire rehydrates the $hub property using
+| whatever the *current* default connection is — so we restore it
+| explicitly before issuing a follow-up action, mirroring what a fresh
+| request would naturally provide.
+*/
+
+test('mount reports table row counts for the tenant database', function () {
+    $teacher = $this->createTeacher();
+    $hub = $this->createHub($teacher, creating: 'users');
+
+    Livewire::actingAs($teacher)
+        ->test(Show::class, ['hub' => $hub])
+        ->assertOk()
+        ->assertSet('adminPassword', null)
+        ->tap(function ($component) {
+            $status = collect($component->get('tableStatus'));
+            expect($status->pluck('name'))->toContain('users');
+            expect($status->firstWhere('name', 'users')['count'])->toBeGreaterThan(0);
+        });
+});
+
+test('fillTables (re)creates an empty tenant table and updates the table status', function () {
+    $teacher = $this->createTeacher();
+    $hub = $this->createHub($teacher, creating: 'users');
+
+    $component = Livewire::actingAs($teacher)
+        ->test(Show::class, ['hub' => $hub]);
+
+    RequestHub::setDefaultDB();
+    $component->call('fillTables', 'ads', 'create');
+
+    $status = collect($component->get('tableStatus'));
+    expect($status->pluck('name'))->toContain('ads');
+    expect($status->firstWhere('name', 'ads')['count'])->toBe(0);
+});
+
+test('resetAdminPassword sets a new password on the tenant admin account', function () {
+    $teacher = $this->createTeacher();
+    $hub = $this->createHub($teacher, creating: 'users');
+
+    $component = Livewire::actingAs($teacher)
+        ->test(Show::class, ['hub' => $hub]);
+
+    RequestHub::setDefaultDB();
+    $component->call('resetAdminPassword');
+
+    $newPassword = $component->get('adminPassword');
+
+    expect($newPassword)->toBeString()->not->toBeEmpty();
+
+    $adminHashedPassword = $this->withinHub($hub, function () {
+        return \App\Models\User::where('username', 'admin')->first()?->password;
+    });
+
+    expect($adminHashedPassword)->not->toBeNull();
+    expect(\Illuminate\Support\Facades\Hash::check($newPassword, $adminHashedPassword))->toBeTrue();
+});

--- a/tests/Feature/Hub/Livewire/PhotoShowTest.php
+++ b/tests/Feature/Hub/Livewire/PhotoShowTest.php
@@ -113,13 +113,50 @@ test('deleteComment is only allowed for dba/admin users', function () {
     });
 });
 
-test('deleteComment removes the comment for a dba user', function () {
+test('deleteComment removes the comment for its author', function () {
     $hub = $this->createHub(creating: 'all_empty');
 
-    $this->withinHub($hub, function () use ($hub) {
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $author = User::factory()->create();
+        $photo = Photo::factory()->for($owner)->create();
+        $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id]);
+
+        $this->actingAs($author);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->call('deleteComment', $comment->id);
+
+        expect(Comment::find($comment->id))->toBeNull();
+    });
+});
+
+test('deleteComment removes the comment for the photo owner', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $author = User::factory()->create();
+        $photo = Photo::factory()->for($owner)->create();
+        $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id]);
+
+        $this->actingAs($owner);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->call('deleteComment', $comment->id);
+
+        expect(Comment::find($comment->id))->toBeNull();
+    });
+});
+
+test('deleteComment does not remove the comment for an unrelated dba user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
         $author = User::factory()->create();
         $dba = User::factory()->dba()->create();
-        $photo = Photo::factory()->for($author)->create();
+        $photo = Photo::factory()->for($owner)->create();
         $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id]);
 
         $this->actingAs($dba);
@@ -127,6 +164,8 @@ test('deleteComment removes the comment for a dba user', function () {
         Livewire::test(Show::class, ['photo' => $photo])
             ->call('deleteComment', $comment->id);
 
-        expect(Comment::find($comment->id))->toBeNull();
+        // The CommentPolicy only allows the author or the photo owner, so a dba
+        // with no relation to the comment cannot delete it.
+        expect(Comment::find($comment->id))->not->toBeNull();
     });
 });

--- a/tests/Feature/Hub/Livewire/PhotoShowTest.php
+++ b/tests/Feature/Hub/Livewire/PhotoShowTest.php
@@ -1,0 +1,132 @@
+<?php
+
+use App\Livewire\Photo\Show;
+use App\Models\Comment;
+use App\Models\Photo;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\Photo\Show
+|--------------------------------------------------------------------------
+|
+| Photos, likes and comments only exist inside a tenant DB, and the
+| component relies on Auth::user() being a tenant user. Every test runs
+| inside withinHub() so RequestHub::isHub() is true and the tenant
+| connection is active for the whole Livewire lifecycle.
+*/
+
+test('renders a photo with its author, likes and comments', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create(['username' => 'author1']);
+        $viewer = User::factory()->dba()->create();
+        $photo = Photo::factory()->for($author)->create(['description' => 'Hello #world']);
+        Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id, 'body' => 'nice shot']);
+
+        $this->actingAs($viewer);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->assertOk()
+            ->assertSet('readonly', false)
+            ->assertSet('admin', true)
+            ->assertSee('author1')
+            ->assertSee('nice shot');
+    });
+});
+
+test('toggleLike creates a like for the current user and removes it on toggle', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create();
+        $viewer = User::factory()->create();
+        $photo = Photo::factory()->for($author)->create();
+
+        $this->actingAs($viewer);
+
+        $component = Livewire::test(Show::class, ['photo' => $photo])
+            ->call('toggleLike');
+
+        expect($photo->fresh()->likes()->where('user_id', $viewer->id)->exists())->toBeTrue();
+
+        $component->call('toggleLike');
+
+        expect($photo->fresh()->likes()->where('user_id', $viewer->id)->exists())->toBeFalse();
+    });
+});
+
+test('postComment stores a new comment and resets the input', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create();
+        $viewer = User::factory()->create();
+        $photo = Photo::factory()->for($author)->create();
+
+        $this->actingAs($viewer);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->set('comment', 'a fresh comment')
+            ->call('postComment')
+            ->assertSet('comment', '')
+            ->assertSet('showInput', false);
+
+        expect($photo->fresh()->comments()->where('body', 'a fresh comment')->exists())->toBeTrue();
+    });
+});
+
+test('postComment requires a non-empty comment', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create();
+        $viewer = User::factory()->create();
+        $photo = Photo::factory()->for($author)->create();
+
+        $this->actingAs($viewer);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->set('comment', '')
+            ->call('postComment')
+            ->assertHasErrors(['comment' => 'required']);
+    });
+});
+
+test('deleteComment is only allowed for dba/admin users', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create();
+        $plainViewer = User::factory()->create();
+        $photo = Photo::factory()->for($author)->create();
+        $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id]);
+
+        $this->actingAs($plainViewer);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->call('deleteComment', $comment->id);
+
+        expect(Comment::find($comment->id))->not->toBeNull();
+    });
+});
+
+test('deleteComment removes the comment for a dba user', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    $this->withinHub($hub, function () use ($hub) {
+        $author = User::factory()->create();
+        $dba = User::factory()->dba()->create();
+        $photo = Photo::factory()->for($author)->create();
+        $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $author->id]);
+
+        $this->actingAs($dba);
+
+        Livewire::test(Show::class, ['photo' => $photo])
+            ->call('deleteComment', $comment->id);
+
+        expect(Comment::find($comment->id))->toBeNull();
+    });
+});

--- a/tests/Feature/Hub/Models/AdTest.php
+++ b/tests/Feature/Hub/Models/AdTest.php
@@ -1,0 +1,165 @@
+<?php
+
+use App\Models\Ad;
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Ad :: getAd()
+|--------------------------------------------------------------------------
+|
+| getAd($photo_id) queries "banner" ads when a photo id is given and "photo"
+| ads otherwise, runs each ad's raw `query` (substituting the literal
+| placeholders "$user"/"$photo"), and decides a match either via a single
+| boolean-like "CASE ..." column or by looking for the current user/photo id
+| among the result rows. All of this only exists on the tenant DB.
+*/
+
+it('is fillable for name, type, priority, url, img and query', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $ad = Ad::create([
+            'name' => 'Sale banner',
+            'type' => 'banner',
+            'priority' => 1,
+            'url' => 'https://example.test',
+            'img' => 'ads/sale.jpg',
+            'query' => 'SELECT 1',
+        ]);
+
+        expect($ad->exists)->toBeTrue();
+        expect($ad->name)->toBe('Sale banner');
+    });
+});
+
+describe('getAd()', function () {
+    it('matches via a CASE-style boolean column when the $user placeholder evaluates truthy', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            Auth::login($user);
+
+            $ad = Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT ($user > 0) as case_matches',
+            ]);
+
+            expect(Ad::getAd()?->id)->toBe($ad->id);
+        });
+    });
+
+    it('does not match a CASE-style boolean column that evaluates falsy', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            Auth::login($user);
+
+            Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT ($user < 0) as case_matches',
+            ]);
+
+            expect(Ad::getAd())->toBeNull();
+        });
+    });
+
+    it('matches "photo" type ads when the authenticated user id is found in a user_id column', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            Auth::login($user);
+
+            $ad = Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT id, id as user_id FROM users',
+            ]);
+
+            expect(Ad::getAd()?->id)->toBe($ad->id);
+        });
+    });
+
+    it('queries "banner" type ads and matches via a photo_id column when a photo id is given', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create();
+
+            $ad = Ad::factory()->create([
+                'type' => 'banner',
+                'priority' => 1,
+                'query' => 'SELECT id, id as photo_id FROM photos',
+            ]);
+            // A "photo" type ad must be ignored when a photo id is given.
+            Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT id, id as photo_id FROM photos',
+            ]);
+
+            expect(Ad::getAd($photo->id)?->id)->toBe($ad->id);
+        });
+    });
+
+    it('returns null when no ad matches', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            Auth::login($user);
+
+            Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT id, id as user_id FROM users WHERE id = -1',
+            ]);
+
+            expect(Ad::getAd())->toBeNull();
+        });
+    });
+
+    it('skips a non-matching ad and falls through to the next one in priority order', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            Auth::login($user);
+
+            Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'SELECT id, id as user_id FROM users WHERE id = -1',
+            ]);
+            $secondAd = Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 2,
+                'query' => 'SELECT id, id as user_id FROM users',
+            ]);
+
+            expect(Ad::getAd()?->id)->toBe($secondAd->id);
+        });
+    });
+
+    it('does not throw when an ad query is broken SQL, and simply yields no match', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            Ad::factory()->create([
+                'type' => 'photo',
+                'priority' => 1,
+                'query' => 'THIS IS NOT VALID SQL',
+            ]);
+
+            expect(fn () => Ad::getAd())->not->toThrow(\Throwable::class);
+            expect(Ad::getAd())->toBeNull();
+        });
+    });
+});

--- a/tests/Feature/Hub/Models/AnalyticTest.php
+++ b/tests/Feature/Hub/Models/AnalyticTest.php
@@ -1,0 +1,98 @@
+<?php
+
+use App\Models\Analytic;
+use App\Models\Photo;
+use App\Models\User;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Analytic
+|--------------------------------------------------------------------------
+*/
+
+it('is fillable for user_id and photo_id only, other columns come from boot()', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create();
+
+        $analytic = Analytic::create([
+            'user_id' => $user->id,
+            'photo_id' => $photo->id,
+        ]);
+
+        expect($analytic->exists)->toBeTrue();
+        expect($analytic->user_id)->toBe($user->id);
+        expect($analytic->photo_id)->toBe($photo->id);
+    });
+});
+
+describe('boot() creating hook', function () {
+    it('populates browser/platform/device metadata and anonymizes the IP', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $analytic = Analytic::factory()->create();
+
+            expect($analytic->device)->not->toBeNull();
+            expect($analytic->browser_family)->not->toBeNull();
+            expect($analytic->platform_family)->not->toBeNull();
+
+            // The last IPv4 octet (or the trailing IPv6 group) is always
+            // zeroed out for anonymization.
+            expect($analytic->ip)->toMatch('/(\.0|:0)$/');
+        });
+    });
+});
+
+describe('relationships', function () {
+    it('belongs to a user and a photo', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            $photo = Photo::factory()->create();
+            $analytic = Analytic::factory()->create(['user_id' => $user->id, 'photo_id' => $photo->id]);
+
+            expect($analytic->user)->toBeInstanceOf(User::class);
+            expect($analytic->user->id)->toBe($user->id);
+
+            expect($analytic->photo)->toBeInstanceOf(Photo::class);
+            expect($analytic->photo->id)->toBe($photo->id);
+        });
+    });
+});
+
+describe('accessors', function () {
+    it('getBrowserAttribute concatenates browser_family and browser_version', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            // boot()'s creating() hook always overwrites browser_family /
+            // browser_version from the (headless, in this test run) request's
+            // user agent, ignoring whatever the factory passed in.
+            $analytic = Analytic::factory()->create();
+
+            expect($analytic->browser)->toBe($analytic->browser_family.' '.$analytic->browser_version);
+        });
+    });
+
+    it('getBrandAttribute reads the (non-existent) device_family/device_model attributes, not brand_family/brand_model', function () {
+        // This documents existing behaviour rather than intended behaviour:
+        // getBrandAttribute() reads `device_family`/`device_model`, but the
+        // actual columns are `brand_family`/`brand_model`. Since those
+        // attributes are never set, Eloquent resolves them to null and the
+        // accessor always returns a single space.
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $analytic = Analytic::factory()->create([
+                'brand_family' => 'Apple',
+                'brand_model' => 'iPhone',
+            ]);
+
+            expect($analytic->brand)->toBe(' ');
+        });
+    });
+});

--- a/tests/Feature/Hub/Models/CommentTest.php
+++ b/tests/Feature/Hub/Models/CommentTest.php
@@ -1,0 +1,59 @@
+<?php
+
+use App\Models\Comment;
+use App\Models\Photo;
+use App\Models\User;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Comment
+|--------------------------------------------------------------------------
+*/
+
+it('is fillable for user_id, photo_id and body', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create();
+
+        $comment = Comment::create([
+            'user_id' => $user->id,
+            'photo_id' => $photo->id,
+            'body' => 'Nice shot!',
+        ]);
+
+        expect($comment->exists)->toBeTrue();
+        expect($comment->body)->toBe('Nice shot!');
+    });
+});
+
+it('belongs to a user, eager loaded by default', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $comment = Comment::factory()->create(['user_id' => $user->id]);
+
+        $fresh = Comment::find($comment->id);
+
+        expect($fresh->relationLoaded('user'))->toBeTrue();
+        expect($fresh->user->id)->toBe($user->id);
+    });
+});
+
+describe('getHtmlAttribute()', function () {
+    it('escapes HTML and links #tags and @mentions', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $comment = Comment::factory()->create(['body' => '<i>rude</i> #cool @bob']);
+
+            $html = $comment->html;
+
+            expect($html)->toContain('&lt;i&gt;rude&lt;/i&gt;');
+            expect($html)->toContain("<a href='/tag/cool'>#cool</a>");
+            expect($html)->toContain("<a href='/bob'>@bob</a>");
+        });
+    });
+});

--- a/tests/Feature/Hub/Models/HubTest.php
+++ b/tests/Feature/Hub/Models/HubTest.php
@@ -1,0 +1,170 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Facades\Schema;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Hub
+|--------------------------------------------------------------------------
+*/
+
+it('belongs to a teacher', function () {
+    $teacher = $this->createTeacher();
+    $hub = Hub::factory()->create(['teacher_id' => $teacher->id]);
+
+    expect($hub->teacher)->toBeInstanceOf(User::class);
+    expect($hub->teacher->id)->toBe($teacher->id);
+});
+
+describe('tenant-backed accessors', function () {
+    it('reports activated=true, an admin username, and a working user once the hub is provisioned with users', function () {
+        $hub = $this->createHub(creating: 'users');
+
+        // `activated` proxies the raw (uncast) `is_active` column, so assert
+        // truthiness rather than strict boolean identity.
+        expect($hub->activated)->toBeTruthy();
+        expect($hub->admin)->toBe('admin');
+        expect($hub->has_working_user)->toBeTrue();
+    });
+
+    it('reports activated=false, no admin and no working user for an empty hub', function () {
+        $hub = $this->createHub(creating: 'all_empty');
+
+        expect($hub->activated)->toBeFalse();
+        expect($hub->admin)->toBeNull();
+        expect($hub->has_working_user)->toBeFalse();
+    });
+
+    it('setActivatedAttribute toggles the dba user\'s is_active flag', function () {
+        $hub = $this->createHub(creating: 'users');
+
+        expect($hub->activated)->toBeTruthy();
+
+        $hub->activated = false;
+        expect($hub->activated)->toBeFalsy();
+
+        $hub->activated = true;
+        expect($hub->activated)->toBeTruthy();
+    });
+
+    it('setActivatedAttribute creates a dba user from scratch when none exists', function () {
+        $hub = $this->createHub(creating: 'all_empty');
+
+        expect($hub->admin)->toBeNull();
+
+        $hub->activated = true;
+
+        expect($hub->admin)->toBe('admin');
+        expect($hub->activated)->toBeTruthy();
+    });
+
+    it('is not readonly right after provisioning (the tenant user has full grants)', function () {
+        $hub = $this->createHub();
+
+        expect($hub->readonly)->toBeFalse();
+    });
+
+    it('setReadonlyAttribute revokes write privileges, and unsetting restores them', function () {
+        $hub = $this->createHub();
+
+        $hub->readonly = true;
+        expect($hub->readonly)->toBeTrue();
+
+        // A freshly loaded instance (no cached accessor) reflects the same
+        // state directly from `mysql.db`.
+        expect($hub->fresh()->readonly)->toBeTrue();
+
+        $hub->readonly = false;
+        expect($hub->readonly)->toBeFalse();
+        expect($hub->fresh()->readonly)->toBeFalse();
+    });
+});
+
+describe('resetAdminPassword()', function () {
+    it('generates a password and updates (or creates) the admin user', function () {
+        $hub = $this->createHub(creating: 'all_empty');
+
+        $password = $hub->resetAdminPassword();
+
+        expect($password)->toBeString();
+        expect($password)->not->toBeEmpty();
+
+        $this->withinHub($hub, function () use ($password) {
+            $admin = User::where('username', 'admin')->first();
+
+            expect($admin)->not->toBeNull();
+            expect(Hash::check($password, $admin->password))->toBeTrue();
+        });
+    });
+});
+
+describe('changeTables() / migrateTable() / fillTable() / dropTable()', function () {
+    it('drops a table via dropTable()', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, fn () => expect(Schema::hasTable('photos'))->toBeTrue());
+
+        $hub->dropTable('photos');
+
+        $this->withinHub($hub, fn () => expect(Schema::hasTable('photos'))->toBeFalse());
+    });
+
+    it('recreates a table via migrateTable() after it has been dropped', function () {
+        $hub = $this->createHub();
+
+        $hub->dropTable('photos');
+        $hub->migrateTable('photos');
+
+        $this->withinHub($hub, function () {
+            expect(Schema::hasTable('photos'))->toBeTrue();
+            expect(DB::table('photos')->count())->toBe(0);
+        });
+    });
+
+    it('fillTable() seeds data and, for users, guarantees a dba admin user', function () {
+        $hub = $this->createHub(creating: 'all_empty');
+
+        $hub->fillTable('users');
+
+        $this->withinHub($hub, function () {
+            expect(User::count())->toBeGreaterThan(0);
+            expect(User::where('role', 'dba')->exists())->toBeTrue();
+        });
+    });
+
+    it('changeTables() applies the requested action to every given table', function () {
+        $hub = $this->createHub();
+
+        $hub->changeTables(['photos', 'tags'], 'drop');
+
+        $this->withinHub($hub, function () {
+            expect(Schema::hasTable('photos'))->toBeFalse();
+            expect(Schema::hasTable('tags'))->toBeFalse();
+        });
+
+        $hub->changeTables(['photos', 'tags'], 'create');
+
+        $this->withinHub($hub, function () {
+            expect(Schema::hasTable('photos'))->toBeTrue();
+            expect(Schema::hasTable('tags'))->toBeTrue();
+        });
+    });
+});
+
+describe('deleting()', function () {
+    it('drops the tenant database and its DB user when the hub is deleted', function () {
+        $hub = $this->createHub();
+        $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+
+        expect(DB::select('SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = ?', [$dbName]))->toHaveCount(1);
+
+        $hub->delete();
+
+        expect(DB::select('SELECT SCHEMA_NAME FROM information_schema.schemata WHERE SCHEMA_NAME = ?', [$dbName]))->toHaveCount(0);
+        expect(DB::select("SELECT User FROM mysql.user WHERE User = ?", [$dbName]))->toHaveCount(0);
+    });
+});

--- a/tests/Feature/Hub/Models/LikeTest.php
+++ b/tests/Feature/Hub/Models/LikeTest.php
@@ -1,0 +1,45 @@
+<?php
+
+use App\Models\Like;
+use App\Models\Photo;
+use App\Models\User;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Like
+|--------------------------------------------------------------------------
+*/
+
+it('is fillable for photo_id and user_id', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create();
+
+        $like = Like::create([
+            'photo_id' => $photo->id,
+            'user_id' => $user->id,
+        ]);
+
+        expect($like->exists)->toBeTrue();
+        expect($like->photo_id)->toBe($photo->id);
+        expect($like->user_id)->toBe($user->id);
+    });
+});
+
+it('belongs to a user and a photo', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $photo = Photo::factory()->create();
+        $like = Like::factory()->create(['user_id' => $user->id, 'photo_id' => $photo->id]);
+
+        expect($like->user)->toBeInstanceOf(User::class);
+        expect($like->user->id)->toBe($user->id);
+
+        expect($like->photo)->toBeInstanceOf(Photo::class);
+        expect($like->photo->id)->toBe($photo->id);
+    });
+});

--- a/tests/Feature/Hub/Models/PhotoTest.php
+++ b/tests/Feature/Hub/Models/PhotoTest.php
@@ -1,0 +1,174 @@
+<?php
+
+use App\Collections\PhotoCollection;
+use App\Models\Analytic;
+use App\Models\Comment;
+use App\Models\Like;
+use App\Models\Photo;
+use App\Models\Tag;
+use App\Models\User;
+use Illuminate\Support\Facades\Storage;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Photo
+|--------------------------------------------------------------------------
+|
+| Photos only exist inside a tenant DB, so every test here provisions a hub
+| and runs inside it via withinHub().
+*/
+
+describe('getHtmlAttribute()', function () {
+    it('escapes HTML and links #tags and @mentions', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create([
+                'description' => '<b>Hello</b> #World @alice',
+            ]);
+
+            $html = $photo->html;
+
+            expect($html)->toContain('&lt;b&gt;Hello&lt;/b&gt;');
+            expect($html)->not->toContain('<b>Hello</b>');
+            expect($html)->toContain("<a href='/tag/World'>#World</a>");
+            expect($html)->toContain("<a href='/alice'>@alice</a>");
+        });
+    });
+
+    it('supports german umlauts in tags and mentions', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['description' => '#Über @Björn']);
+
+            $html = $photo->html;
+
+            expect($html)->toContain("<a href='/tag/Über'>#Über</a>");
+            expect($html)->toContain("<a href='/Björn'>@Björn</a>");
+        });
+    });
+});
+
+describe('updateTags()', function () {
+    it('parses #hashtags from the description into lowercase tag rows on create', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['description' => 'Look at this #Sunset #BEACH day']);
+
+            $names = $photo->tags()->orderBy('id')->pluck('name')->all();
+
+            expect($names)->toBe(['sunset', 'beach']);
+        });
+    });
+
+    it('allows duplicate tags for repeated hashtags', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['description' => '#foo #Foo #FOO']);
+
+            expect($photo->tags()->orderBy('id')->pluck('name')->all())->toBe(['foo', 'foo', 'foo']);
+        });
+    });
+
+    it('creates no tags when the description has no hashtags', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['description' => 'just a plain caption']);
+
+            expect($photo->tags()->count())->toBe(0);
+        });
+    });
+
+    it('replaces old tags with new ones when the description is updated', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['description' => '#old']);
+            expect($photo->tags()->orderBy('id')->pluck('name')->all())->toBe(['old']);
+
+            $photo->update(['description' => '#new']);
+
+            expect($photo->fresh()->tags()->orderBy('id')->pluck('name')->all())->toBe(['new']);
+        });
+    });
+});
+
+describe('relationships', function () {
+    it('exposes user, likes, comments, tags and viewers', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $owner = User::factory()->create();
+            $liker = User::factory()->create();
+            $photo = Photo::factory()->create(['user_id' => $owner->id, 'description' => '#hi']);
+
+            $like = Like::factory()->create(['photo_id' => $photo->id, 'user_id' => $liker->id]);
+            $comment = Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $liker->id]);
+            $view = Analytic::factory()->create(['photo_id' => $photo->id, 'user_id' => $liker->id]);
+
+            expect($photo->user)->toBeInstanceOf(User::class);
+            expect($photo->user->id)->toBe($owner->id);
+
+            expect($photo->likes)->toHaveCount(1);
+            expect($photo->likes->first()->id)->toBe($like->id);
+
+            expect($photo->comments)->toHaveCount(1);
+            expect($photo->comments->first()->id)->toBe($comment->id);
+
+            expect($photo->tags)->toHaveCount(1);
+            expect($photo->tags->first())->toBeInstanceOf(Tag::class);
+
+            expect($photo->viewers)->toHaveCount(1);
+            expect($photo->viewers->first()->id)->toBe($view->id);
+        });
+    });
+});
+
+describe('newCollection()', function () {
+    it('returns a PhotoCollection instance from queries', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            Photo::factory()->count(2)->create();
+
+            expect(Photo::all())->toBeInstanceOf(PhotoCollection::class);
+            expect(Photo::query()->get())->toBeInstanceOf(PhotoCollection::class);
+        });
+    });
+});
+
+describe('deleting()', function () {
+    it('deletes the stored file from disk when the photo is deleted', function () {
+        Storage::fake('local');
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            Storage::disk('local')->put('photos/to-delete.jpg', 'fake-contents');
+
+            $photo = Photo::factory()->create(['url' => 'photos/to-delete.jpg']);
+
+            expect(Storage::disk('local')->exists('photos/to-delete.jpg'))->toBeTrue();
+
+            $photo->delete();
+
+            expect(Storage::disk('local')->exists('photos/to-delete.jpg'))->toBeFalse();
+        });
+    });
+
+    it('does not error when the file is already missing', function () {
+        Storage::fake('local');
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $photo = Photo::factory()->create(['url' => 'photos/never-existed.jpg']);
+
+            $photo->delete();
+
+            expect(Photo::find($photo->id))->toBeNull();
+        });
+    });
+});

--- a/tests/Feature/Hub/Models/TagTest.php
+++ b/tests/Feature/Hub/Models/TagTest.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Photo;
+use App\Models\Tag;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\Tag
+|--------------------------------------------------------------------------
+*/
+
+it('is fillable for photo_id and name', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        // Use a description without hashtags so Photo::updateTags() does not
+        // wipe out the tag we create manually below.
+        $photo = Photo::factory()->create(['description' => 'no hashtags here']);
+
+        $tag = Tag::create([
+            'photo_id' => $photo->id,
+            'name' => 'sunset',
+        ]);
+
+        expect($tag->exists)->toBeTrue();
+        expect($tag->name)->toBe('sunset');
+    });
+});
+
+it('belongs to a photo', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $photo = Photo::factory()->create(['description' => 'no hashtags here']);
+        $tag = Tag::factory()->create(['photo_id' => $photo->id]);
+
+        expect($tag->photo)->toBeInstanceOf(Photo::class);
+        expect($tag->photo->id)->toBe($photo->id);
+    });
+});

--- a/tests/Feature/Hub/Models/UserHubTest.php
+++ b/tests/Feature/Hub/Models/UserHubTest.php
@@ -1,0 +1,126 @@
+<?php
+
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\User (tenant-only behaviour)
+|--------------------------------------------------------------------------
+|
+| following()/followers()/photos()/isfollowing() rely on the tenant-only
+| `follows`/`photos` tables, and getSuggested() runs raw SQL (FIELD()) that
+| requires a real hub database. All of these must run inside a provisioned
+| hub.
+*/
+
+describe('following() / followers() / isfollowing()', function () {
+    it('reports a followed user via following(), isfollowing() and the inverse via followers()', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $a = User::factory()->create();
+            $b = User::factory()->create();
+
+            // Pivot columns are (following_id, follower_id); belongsToMany maps
+            // following(): foreignPivotKey=following_id, relatedPivotKey=follower_id.
+            DB::table('follows')->insert([
+                'following_id' => $a->id,
+                'follower_id' => $b->id,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            expect($a->following()->get()->pluck('id'))->toContain($b->id);
+            expect($a->isfollowing($b))->toBe(1);
+
+            expect($b->followers()->get()->pluck('id'))->toContain($a->id);
+            expect($b->isfollowing($a))->toBe(0);
+        });
+    });
+});
+
+describe('photos() relationship', function () {
+    it('returns only this user\'s photos, newest first', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $user = User::factory()->create();
+            $other = User::factory()->create();
+
+            $older = Photo::factory()->create(['user_id' => $user->id, 'created_at' => now()->subDay()]);
+            $newer = Photo::factory()->create(['user_id' => $user->id, 'created_at' => now()]);
+            Photo::factory()->create(['user_id' => $other->id]);
+
+            $photos = $user->photos;
+
+            expect($photos)->toHaveCount(2);
+            expect($photos->first()->id)->toBe($newer->id);
+            expect($photos->last()->id)->toBe($older->id);
+        });
+    });
+});
+
+describe('getSuggested()', function () {
+    it('excludes users who already follow the authenticated user and ranks photo owners higher', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $auth = User::factory()->create();
+            $alreadyFollower = User::factory()->create();
+            $withPhotos = User::factory()->create();
+            $plain = User::factory()->create();
+
+            // $alreadyFollower follows $auth -> the "remove already related"
+            // query in getSuggested() matches follower_id = X, following_id = auth.
+            DB::table('follows')->insert([
+                'following_id' => $auth->id,
+                'follower_id' => $alreadyFollower->id,
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            Photo::factory()->count(3)->create(['user_id' => $withPhotos->id]);
+
+            Auth::login($auth);
+
+            $suggestions = User::getSuggested(10);
+            $ids = $suggestions->pluck('id')->all();
+
+            expect($ids)->not->toContain($alreadyFollower->id);
+            expect($ids)->toContain($withPhotos->id);
+            expect($ids)->toContain($plain->id);
+
+            // Every returned suggestion carries its computed score.
+            foreach ($suggestions as $suggestion) {
+                expect($suggestion->score)->not->toBeNull();
+            }
+
+            // The user with uploaded photos scores strictly higher than one
+            // with no relation at all, and therefore sorts before it.
+            $withPhotosScore = $suggestions->firstWhere('id', $withPhotos->id)->score;
+            $plainScore = $suggestions->firstWhere('id', $plain->id)->score;
+            expect($withPhotosScore)->toBeGreaterThan($plainScore);
+
+            $indexOfWithPhotos = $ids ? array_search($withPhotos->id, $ids) : null;
+            $indexOfPlain = array_search($plain->id, $ids);
+            expect($indexOfWithPhotos)->toBeLessThan($indexOfPlain);
+        });
+    });
+
+    it('respects the given limit', function () {
+        $hub = $this->createHub();
+
+        $this->withinHub($hub, function () {
+            $auth = User::factory()->create();
+            User::factory()->count(5)->create();
+            Auth::login($auth);
+
+            $suggestions = User::getSuggested(2);
+
+            expect($suggestions->count())->toBeLessThanOrEqual(2);
+        });
+    });
+});

--- a/tests/Feature/Hub/Support/AdResourceTest.php
+++ b/tests/Feature/Hub/Support/AdResourceTest.php
@@ -1,0 +1,27 @@
+<?php
+
+use App\Http\Resources\Ad as AdResource;
+use App\Models\Ad;
+
+it('exposes the id, name, type, url and img fields', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $ad = Ad::factory()->create([
+            'name' => 'Summer Sale',
+            'type' => 'banner',
+            'url' => 'https://example.test/ad',
+            'img' => 'ads/summer.jpg',
+        ]);
+
+        $data = (new AdResource($ad))->toArray(request());
+
+        expect($data)->toBe([
+            'id' => $ad->id,
+            'name' => 'Summer Sale',
+            'type' => 'banner',
+            'url' => 'https://example.test/ad',
+            'img' => 'ads/summer.jpg',
+        ]);
+    });
+});

--- a/tests/Feature/Hub/Support/CommentResourceTest.php
+++ b/tests/Feature/Hub/Support/CommentResourceTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use App\Http\Resources\Comment as CommentResource;
+use App\Models\Comment;
+use App\Models\Photo;
+use App\Models\User;
+
+it('exposes id, escaped html text and the comment owner', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create(['name' => 'Commenter', 'username' => 'commenter', 'avatar' => 'avatar.png']);
+        $photo = Photo::factory()->create();
+        $comment = Comment::factory()->create([
+            'user_id' => $owner->id,
+            'photo_id' => $photo->id,
+            'body' => '<script>alert(1)</script>',
+        ]);
+
+        $data = (new CommentResource($comment))->toArray(request());
+
+        expect($data['id'])->toBe($comment->id);
+        expect($data['text'])->toBe($comment->html);
+        expect($data['text'])->not->toContain('<script>');
+        expect($data['owner'])->toBeInstanceOf(\App\Http\Resources\User::class);
+
+        $ownerArray = $data['owner']->toArray(request());
+        expect($ownerArray)->toBe([
+            'username' => 'commenter',
+            'name' => 'Commenter',
+            'avatar' => 'avatar.png',
+        ]);
+    });
+});

--- a/tests/Feature/Hub/Support/FollowResourceTest.php
+++ b/tests/Feature/Hub/Support/FollowResourceTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Http\Resources\Follow as FollowResource;
+use App\Http\Resources\FollowFollower as FollowFollowerResource;
+use App\Models\User;
+
+it('exposes id, name, username and the collection of followed users', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create(['name' => 'Alice', 'username' => 'alice']);
+        $followedUser = User::factory()->create(['name' => 'Bob', 'username' => 'bob']);
+
+        // $user->following() is keyed so that attach() records $user as the
+        // "following_id" side and $followedUser as "follower_id" (see
+        // App\Models\User::following()).
+        $user->following()->attach($followedUser->id);
+
+        $data = (new FollowResource($user))->toArray(request());
+
+        expect($data['id'])->toBe($user->id);
+        expect($data['name'])->toBe('Alice');
+        expect($data['username'])->toBe('alice');
+        expect($data['follows'])->toHaveCount(1);
+        expect($data['follows'][0])->toBeInstanceOf(FollowFollowerResource::class);
+    });
+});
+
+it('returns an empty follows collection when the user follows nobody', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+
+        $data = (new FollowResource($user))->toArray(request());
+
+        expect($data['follows'])->toHaveCount(0);
+    });
+});
+
+it('FollowFollower exposes id, name, username and the pivot "since" timestamp', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $user = User::factory()->create();
+        $followedUser = User::factory()->create(['name' => 'Bob', 'username' => 'bob']);
+
+        $user->following()->attach($followedUser->id);
+
+        $followed = $user->following()->first();
+        $data = (new FollowFollowerResource($followed))->toArray(request());
+
+        expect($data['id'])->toBe($followedUser->id);
+        expect($data['name'])->toBe('Bob');
+        expect($data['username'])->toBe('bob');
+        expect($data['since'])->toBe($followed->pivot->created_at->toDateTimeString());
+    });
+});

--- a/tests/Feature/Hub/Support/HubHelperHubContextTest.php
+++ b/tests/Feature/Hub/Support/HubHelperHubContextTest.php
@@ -1,0 +1,78 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Models\Hub;
+use App\Models\User;
+
+/*
+|--------------------------------------------------------------------------
+| Hub-context behaviour of App\Helpers\HubHelper
+|--------------------------------------------------------------------------
+|
+| Uses ProvisionsHubs::createHub()/withinHub() to provision a real tenant
+| database and switch the app into hub context (RequestHub::isHub() ===
+| true), exercising the parts of HubHelper that only make sense once a hub
+| subdomain has been detected.
+*/
+
+it('reports hub identity, teacher and generation once inside a hub', function () {
+    $teacher = $this->createTeacher(['hub_default_generation' => 1, 'hub_default_query_level' => 'sql']);
+    $hub = $this->createHub($teacher, ['generation' => 1, 'query_level' => 'sql']);
+
+    $this->withinHub($hub, function () use ($hub, $teacher) {
+        expect(RequestHub::isHub())->toBeTrue();
+        expect(RequestHub::id())->toBe($hub->id);
+        expect(RequestHub::name())->toBe($hub->name);
+        expect(RequestHub::generation())->toBe(1);
+        expect(RequestHub::query_level())->toBe('sql');
+
+        $resolvedTeacher = RequestHub::teacher();
+        expect($resolvedTeacher)->toBeInstanceOf(User::class);
+        expect($resolvedTeacher->id)->toBe($teacher->id);
+    });
+});
+
+it('hasTable reflects the tenant database schema, not the primary one', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () use ($hub) {
+        expect(RequestHub::hasTable('users'))->toBeTrue();
+        expect(RequestHub::hasTable('photos'))->toBeTrue();
+        // "hubs" only exists on the primary database, not inside a tenant DB.
+        expect(RequestHub::hasTable('hubs'))->toBeFalse();
+    });
+});
+
+it('isHub is false again once execution returns to the primary database', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        expect(RequestHub::isHub())->toBeTrue();
+    });
+
+    expect(RequestHub::isHub())->toBeFalse();
+    expect(RequestHub::id())->toBeNull();
+});
+
+it('hasTokens delegates to the hub teacher while inside a hub', function () {
+    $teacher = $this->createTeacher();
+    $teacher->update(['tokens_used' => 5, 'tokens_max' => 10]);
+    $hub = $this->createHub($teacher);
+
+    $this->withinHub($hub, function () {
+        expect(RequestHub::hasTokens(5))->toBeTrue();
+        expect(RequestHub::hasTokens(6))->toBeFalse();
+    });
+});
+
+it('decrementTokens increments tokens_used on the hub teacher in the primary DB', function () {
+    $teacher = $this->createTeacher();
+    $teacher->update(['tokens_used' => 0]);
+    $hub = $this->createHub($teacher);
+
+    $this->withinHub($hub, function () {
+        RequestHub::decrementTokens(4);
+    });
+
+    expect($teacher->fresh()->tokens_used)->toBe(4);
+});

--- a/tests/Feature/Hub/Support/HubResourceTest.php
+++ b/tests/Feature/Hub/Support/HubResourceTest.php
@@ -1,0 +1,33 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Http\Resources\Hub as HubResource;
+
+/*
+|--------------------------------------------------------------------------
+| KNOWN APP BUG (not fixed here, per test-writing instructions):
+|--------------------------------------------------------------------------
+|
+| App\Http\Resources\Hub::toArray() calls $this->hasWorkingUser(),
+| $this->activated() and $this->readonly() as *methods*. Those only exist
+| as Eloquent accessors on App\Models\Hub (getHasWorkingUserAttribute(),
+| getActivatedAttribute(), getReadonlyAttribute()), reachable only via
+| *property* access ($this->hasWorkingUser), not as real methods. Because
+| JsonResource forwards unknown method calls to the underlying model via
+| ForwardsCalls, calling them as methods throws BadMethodCallException
+| ("Call to undefined method App\Http\Resources\Hub::hasWorkingUser()")
+| before any array can be built - toArray() is unusable in its current
+| form for any Hub instance.
+*/
+
+it('toArray() currently throws because of accessor/method-call bugs in the resource', function () {
+    $hub = $this->createHub(creating: 'all_empty');
+
+    RequestHub::setDefaultDB();
+
+    expect(fn () => (new HubResource($hub))->toArray(request()))
+        ->toThrow(BadMethodCallException::class);
+})->skip('App\Http\Resources\Hub::toArray() calls $this->hasWorkingUser()/activated()/readonly() as '
+    .'methods instead of accessing them as Eloquent accessor properties, so toArray() always throws '
+    .'BadMethodCallException. This is an app bug in app/Http/Resources/Hub.php, not a test issue; '
+    .'not fixed here since editing app code is out of scope.');

--- a/tests/Feature/Hub/Support/HubResourceTest.php
+++ b/tests/Feature/Hub/Support/HubResourceTest.php
@@ -3,31 +3,29 @@
 use App\Facades\RequestHub;
 use App\Http\Resources\Hub as HubResource;
 
-/*
-|--------------------------------------------------------------------------
-| KNOWN APP BUG (not fixed here, per test-writing instructions):
-|--------------------------------------------------------------------------
-|
-| App\Http\Resources\Hub::toArray() calls $this->hasWorkingUser(),
-| $this->activated() and $this->readonly() as *methods*. Those only exist
-| as Eloquent accessors on App\Models\Hub (getHasWorkingUserAttribute(),
-| getActivatedAttribute(), getReadonlyAttribute()), reachable only via
-| *property* access ($this->hasWorkingUser), not as real methods. Because
-| JsonResource forwards unknown method calls to the underlying model via
-| ForwardsCalls, calling them as methods throws BadMethodCallException
-| ("Call to undefined method App\Http\Resources\Hub::hasWorkingUser()")
-| before any array can be built - toArray() is unusable in its current
-| form for any Hub instance.
-*/
-
-it('toArray() currently throws because of accessor/method-call bugs in the resource', function () {
+it('serializes a hub with no working user (empty tenant) to the expected shape', function () {
     $hub = $this->createHub(creating: 'all_empty');
 
     RequestHub::setDefaultDB();
 
-    expect(fn () => (new HubResource($hub))->toArray(request()))
-        ->toThrow(BadMethodCallException::class);
-})->skip('App\Http\Resources\Hub::toArray() calls $this->hasWorkingUser()/activated()/readonly() as '
-    .'methods instead of accessing them as Eloquent accessor properties, so toArray() always throws '
-    .'BadMethodCallException. This is an app bug in app/Http/Resources/Hub.php, not a test issue; '
-    .'not fixed here since editing app code is out of scope.');
+    $data = (new HubResource($hub))->toArray(request());
+
+    expect($data)->toHaveKeys(['id', 'name', 'hasWorkingUser', 'activated', 'admin', 'readonly', 'created_at'])
+        ->and($data['id'])->toBe($hub->id)
+        ->and($data['name'])->toBe($hub->name)
+        ->and($data['hasWorkingUser'])->toBeFalse() // all_empty seeds no dba user
+        ->and($data['activated'])->toBeFalse()
+        ->and($data['admin'])->toBe('');
+});
+
+it('reports a working, activated hub once a dba user exists', function () {
+    $hub = $this->createHub(creating: 'users');
+
+    RequestHub::setDefaultDB();
+
+    $data = (new HubResource($hub))->toArray(request());
+
+    expect($data['hasWorkingUser'])->toBeTrue()
+        ->and($data['activated'])->toBeTruthy()
+        ->and($data['admin'])->toBe('admin');
+});

--- a/tests/Feature/Hub/Support/PhotoCollectionTest.php
+++ b/tests/Feature/Hub/Support/PhotoCollectionTest.php
@@ -1,0 +1,135 @@
+<?php
+
+use App\Collections\PhotoCollection;
+use App\Models\Comment;
+use App\Models\Like;
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+it('Photo::all() returns a PhotoCollection instance', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        Photo::factory()->create(['user_id' => $owner->id]);
+
+        expect(Photo::all())->toBeInstanceOf(PhotoCollection::class);
+    });
+});
+
+it('addPhotoScoreGlobal ranks photos with more likes/comments higher', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $liker = User::factory()->create();
+        $commenter = User::factory()->create();
+
+        $popular = Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()]);
+        $quiet = Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()]);
+
+        Like::factory()->create(['photo_id' => $popular->id, 'user_id' => $liker->id]);
+        Comment::factory()->create(['photo_id' => $popular->id, 'user_id' => $commenter->id]);
+
+        $scored = Photo::all()->addPhotoScoreGlobal();
+
+        $popularScored = $scored->firstWhere('id', $popular->id);
+        $quietScored = $scored->firstWhere('id', $quiet->id);
+
+        expect($popularScored->score)->toBeGreaterThan($quietScored->score);
+        expect($popularScored->score_edge_likes)->toBe(1);
+        expect($popularScored->score_edge_comments)->toBe(2);
+        expect($quietScored->score_edge_likes)->toBe(0);
+
+        // Sorted descending by score: the popular photo comes first.
+        expect($scored->first()->id)->toBe($popular->id);
+    });
+});
+
+it('addPhotoScoreGlobal decays scores of old photos toward the floor of 0.01', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+
+        $fresh = Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()]);
+        $old = Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()->subDays(30)]);
+
+        $scored = Photo::all()->addPhotoScoreGlobal();
+
+        $freshScored = $scored->firstWhere('id', $fresh->id);
+        $oldScored = $scored->firstWhere('id', $old->id);
+
+        expect($oldScored->score_decay)->toBe(0.01);
+        expect($freshScored->score_decay)->toBeGreaterThan($oldScored->score_decay);
+        expect($scored->first()->id)->toBe($fresh->id);
+    });
+});
+
+it('addPhotoScore boosts photos from users the current user has interacted with', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $currentUser = User::factory()->create();
+        $friendAuthor = User::factory()->create();
+        $strangerAuthor = User::factory()->create();
+
+        $friendPhoto = Photo::factory()->create(['user_id' => $friendAuthor->id, 'created_at' => now()]);
+        $strangerPhoto = Photo::factory()->create(['user_id' => $strangerAuthor->id, 'created_at' => now()]);
+
+        // The current user has liked and commented on the friend's photos
+        // before (affinity signal), but never interacted with the stranger.
+        Like::factory()->create(['photo_id' => $friendPhoto->id, 'user_id' => $currentUser->id]);
+        Comment::factory()->create(['photo_id' => $friendPhoto->id, 'user_id' => $currentUser->id]);
+
+        Auth::login($currentUser);
+
+        $scored = Photo::all()->addPhotoScore();
+
+        $friendScored = $scored->firstWhere('id', $friendPhoto->id);
+        $strangerScored = $scored->firstWhere('id', $strangerPhoto->id);
+
+        expect($friendScored->score_affinity)->toBeGreaterThan($strangerScored->score_affinity);
+        expect($strangerScored->score_affinity)->toBe(1);
+    });
+});
+
+it('addPhotoScore falls back to affinity 1 when the follows table is absent', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () use ($hub) {
+        $owner = User::factory()->create();
+        $currentUser = User::factory()->create();
+        Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()]);
+
+        // Drop the follows table so RequestHub::hasTable('follows') is false
+        // and the collection takes the "no affinity data available" branch.
+        $hub->dropTable('follows');
+
+        Auth::login($currentUser);
+
+        $scored = Photo::all()->addPhotoScore();
+
+        expect($scored->first()->score_affinity)->toBe(1);
+    });
+});
+
+it('addPhotoScore respects custom weights', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $liker = User::factory()->create();
+
+        $photo = Photo::factory()->create(['user_id' => $owner->id, 'created_at' => now()]);
+        Like::factory()->create(['photo_id' => $photo->id, 'user_id' => $liker->id]);
+
+        Auth::login($liker);
+
+        $scored = Photo::all()->addPhotoScore(['like_edge' => 100]);
+
+        expect($scored->first()->score_edge_likes)->toBeGreaterThanOrEqual(100);
+        expect($scored->first()->score_weights['like_edge'])->toBe(100);
+    });
+});

--- a/tests/Feature/Hub/Support/PhotoResourceTest.php
+++ b/tests/Feature/Hub/Support/PhotoResourceTest.php
@@ -1,0 +1,80 @@
+<?php
+
+use App\Http\Resources\Photo as PhotoResource;
+use App\Models\Comment;
+use App\Models\Like;
+use App\Models\Photo;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+it('exposes id, description, url, owner, like state, like count and comments', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create(['name' => 'Owner', 'username' => 'owner', 'avatar' => 'avatar.png']);
+        $viewer = User::factory()->create();
+
+        $photo = Photo::factory()->create([
+            'user_id' => $owner->id,
+            'description' => 'a nice #sunset',
+            'url' => 'photos/sunset.jpg',
+        ]);
+
+        Like::factory()->create(['photo_id' => $photo->id, 'user_id' => $viewer->id]);
+        Comment::factory()->create(['photo_id' => $photo->id, 'user_id' => $viewer->id, 'body' => 'nice shot']);
+
+        Auth::login($viewer);
+
+        $data = (new PhotoResource($photo))->resolve();
+
+        expect($data['id'])->toBe($photo->id);
+        expect($data['url'])->toBe('photos/sunset.jpg');
+        expect($data['owner']->toArray(request()))->toBe([
+            'username' => 'owner',
+            'name' => 'Owner',
+            'avatar' => 'avatar.png',
+        ]);
+        expect($data['like'])->toBeTrue();
+        expect($data['likes'])->toBe(1);
+        expect($data['comments'])->toHaveCount(1);
+    });
+});
+
+it('reports like as false when the current user has not liked the photo', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () {
+        $owner = User::factory()->create();
+        $viewer = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+
+        Auth::login($viewer);
+
+        $data = (new PhotoResource($photo))->resolve();
+
+        expect($data['like'])->toBeFalse();
+        expect($data['likes'])->toBe(0);
+        expect($data['comments'])->toHaveCount(0);
+    });
+});
+
+it('omits like/likes/comments entirely when their tables do not exist', function () {
+    $hub = $this->createHub();
+
+    $this->withinHub($hub, function () use ($hub) {
+        $owner = User::factory()->create();
+        $photo = Photo::factory()->create(['user_id' => $owner->id]);
+
+        $hub->dropTable('likes');
+        $hub->dropTable('comments');
+
+        Auth::login($owner);
+
+        $data = (new PhotoResource($photo))->resolve();
+
+        expect($data)->not->toHaveKey('like');
+        expect($data)->not->toHaveKey('likes');
+        expect($data)->not->toHaveKey('comments');
+        expect($data['id'])->toBe($photo->id);
+    });
+});

--- a/tests/Feature/Livewire/Admin/SqlAiTest.php
+++ b/tests/Feature/Livewire/Admin/SqlAiTest.php
@@ -1,0 +1,49 @@
+<?php
+
+use App\Livewire\Admin\SqlAi;
+use App\Models\User;
+use Livewire\Livewire;
+
+/*
+|--------------------------------------------------------------------------
+| App\Livewire\Admin\SqlAi
+|--------------------------------------------------------------------------
+|
+| runQuery() calls out to an external OpenAI-compatible API whenever a
+| prompt is present, so only the network-free paths are covered here:
+| mount()'s table loading and the early return for an empty prompt. The
+| view also calls RequestHub::hasTokens(), which needs an authenticated
+| user outside of a hub.
+*/
+
+test('mount loads the last prompt from the session and the table list', function () {
+    session(['last_prompt' => 'show me all users']);
+
+    Livewire::actingAs(User::factory()->admin()->create())
+        ->test(SqlAi::class)
+        ->assertSet('prompt', 'show me all users')
+        ->assertSet('query', '')
+        ->tap(function ($component) {
+            expect($component->get('tables'))->toContain('users');
+        });
+});
+
+test('running the query with an empty prompt does nothing', function () {
+    Livewire::actingAs(User::factory()->admin()->create())
+        ->test(SqlAi::class)
+        ->set('prompt', '')
+        ->call('runQuery')
+        ->assertSet('query', '')
+        ->assertSet('message', null)
+        ->assertSet('results', []);
+});
+
+test('unsetResults clears results and message', function () {
+    Livewire::actingAs(User::factory()->admin()->create())
+        ->test(SqlAi::class)
+        ->set('message', ['type' => 'success', 'text' => 'x'])
+        ->set('results', [1, 2, 3])
+        ->call('unsetResults')
+        ->assertSet('message', null)
+        ->assertSet('results', []);
+});

--- a/tests/Feature/Livewire/Admin/SqlBuilderTest.php
+++ b/tests/Feature/Livewire/Admin/SqlBuilderTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Livewire\Admin\SqlBuilder;
+use Livewire\Livewire;
+
+test('mount loads the available tables and columns of the current database', function () {
+    $component = Livewire::test(SqlBuilder::class);
+
+    $component->assertOk();
+    expect($component->get('tablenames'))->toContain('users');
+    expect($component->get('tables')['users'])->toContain('username');
+});
+
+test('selecting a single table exposes its columns as attributes and query rules', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('sql.tables', ['users'])
+        ->assertSet('attr', fn ($attr) => in_array('username', $attr))
+        ->tap(function ($component) {
+            $rules = $component->get('rules');
+            expect($rules)->not->toBeEmpty();
+            expect($rules[0])->toHaveKeys(['type', 'id', 'label']);
+        });
+});
+
+test('selecting multiple tables prefixes attributes with the table name', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('sql.tables', ['users', 'hubs'])
+        ->tap(function ($component) {
+            $attr = $component->get('attr');
+            expect(collect($attr)->every(fn ($a) => str_contains($a, '.')))->toBeTrue();
+        });
+});
+
+test('getResult runs the raw query and reports success', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('query', 'select 1 as one')
+        ->call('getResult')
+        ->assertSet('message.type', 'success');
+});
+
+test('getResult reports a warning for zero results', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('query', 'select * from users where 1 = 0')
+        ->call('getResult')
+        ->assertSet('message.type', 'warning');
+});
+
+test('getResult reports a danger message for an invalid query', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('query', 'select * from a_table_that_does_not_exist')
+        ->call('getResult')
+        ->assertSet('message.type', 'danger');
+});
+
+test('unsetResults clears message and results', function () {
+    Livewire::test(SqlBuilder::class)
+        ->set('query', 'select 1 as one')
+        ->call('getResult')
+        ->assertSet('message.type', 'success')
+        ->call('unsetResults')
+        ->assertSet('message', null)
+        ->assertSet('results', []);
+});

--- a/tests/Feature/Livewire/Admin/SqlTest.php
+++ b/tests/Feature/Livewire/Admin/SqlTest.php
@@ -1,0 +1,58 @@
+<?php
+
+use App\Livewire\Admin\Sql;
+use Livewire\Livewire;
+
+test('mount loads the current database table/column list', function () {
+    Livewire::test(Sql::class)
+        ->assertSet('query', '')
+        ->assertSee('users');
+});
+
+test('a successful select query populates results and a success message', function () {
+    Livewire::test(Sql::class)
+        ->set('query', 'select 1 as one')
+        ->call('runQuery')
+        ->assertSet('message.type', 'success');
+});
+
+test('a select query with zero rows reports a warning', function () {
+    Livewire::test(Sql::class)
+        ->set('query', 'select * from users where 1 = 0')
+        ->call('runQuery')
+        ->assertSet('message.type', 'warning');
+});
+
+test('a non-select statement is executed directly', function () {
+    $component = Livewire::test(Sql::class)
+        ->set('query', "update users set name = name where 1 = 0")
+        ->call('runQuery');
+
+    $component->assertSet('message.type', 'success')
+        ->assertSet('message.text', __('Query executed.'));
+});
+
+test('an invalid query reports a danger message with the SQL error', function () {
+    Livewire::test(Sql::class)
+        ->set('query', 'select * from a_table_that_does_not_exist')
+        ->call('runQuery')
+        ->assertSet('message.type', 'danger');
+});
+
+test('the last query is remembered across runs via the session', function () {
+    Livewire::test(Sql::class)
+        ->set('query', 'select 1')
+        ->call('runQuery');
+
+    expect(session('last_query'))->toBe('select 1');
+});
+
+test('unsetResults clears results and message', function () {
+    Livewire::test(Sql::class)
+        ->set('query', 'select 1 as one')
+        ->call('runQuery')
+        ->assertSet('message.type', 'success')
+        ->call('unsetResults')
+        ->assertSet('message', null)
+        ->assertSet('results', []);
+});

--- a/tests/Feature/Livewire/UserActivateTest.php
+++ b/tests/Feature/Livewire/UserActivateTest.php
@@ -1,0 +1,41 @@
+<?php
+
+use App\Livewire\UserActivate;
+use App\Models\User;
+use Illuminate\Support\Facades\Notification;
+use Livewire\Livewire;
+
+test('mount exposes the user and the current read-only state', function () {
+    $target = User::factory()->create(['is_active' => false]);
+
+    Livewire::test(UserActivate::class, ['user' => $target])
+        ->assertOk()
+        ->assertSet('isReadOnly', false)
+        ->assertSee(__('Activate'));
+});
+
+test('toggleActive flips an inactive user to active', function () {
+    Notification::fake();
+
+    // Activating a user triggers User::boot()'s "updating" listener, which
+    // builds a UserActivated notification via RequestHub::url() — that reads
+    // $_SERVER['HTTP_HOST'], only populated for real HTTP requests.
+    $_SERVER['HTTP_HOST'] = 'admin.localhost';
+
+    $target = User::factory()->create(['is_active' => false]);
+
+    Livewire::test(UserActivate::class, ['user' => $target])
+        ->call('toggleActive');
+
+    expect($target->fresh()->is_active)->toBeTruthy();
+    Notification::assertSentTo($target, \App\Notifications\UserActivated::class);
+});
+
+test('toggleActive flips an active user to inactive', function () {
+    $target = User::factory()->create(['is_active' => true]);
+
+    Livewire::test(UserActivate::class, ['user' => $target])
+        ->call('toggleActive');
+
+    expect($target->fresh()->is_active)->toBeFalsy();
+});

--- a/tests/Feature/Livewire/UserHubSettingsTest.php
+++ b/tests/Feature/Livewire/UserHubSettingsTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Livewire\UserHubSettings;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('mount fills the form from the authenticated user defaults', function () {
+    $teacher = User::factory()->teacher()->create([
+        'hub_default_generation' => 1,
+        'hub_default_creating' => 'all_empty',
+        'hub_default_query_level' => 'gui',
+    ]);
+
+    Livewire::actingAs($teacher)
+        ->test(UserHubSettings::class)
+        ->assertSet('generation', 1)
+        ->assertSet('hubDefaultCreating', 'all_empty')
+        ->assertSet('hubDefaultQueryLevel', 'gui')
+        ->assertSet('availableGenerations', config('hub.generations'));
+});
+
+test('save persists valid settings and flashes a success message', function () {
+    $teacher = User::factory()->teacher()->create([
+        'hub_default_generation' => 1,
+        'hub_default_creating' => 'all_empty',
+        'hub_default_query_level' => 'gui',
+    ]);
+
+    Livewire::actingAs($teacher)
+        ->test(UserHubSettings::class)
+        ->set('generation', 2)
+        ->set('hubDefaultCreating', 'all_full')
+        ->set('hubDefaultQueryLevel', 'sql')
+        ->call('save')
+        ->assertHasNoErrors()
+        ->assertSee(__('Settings updated successfully.'));
+
+    $teacher->refresh();
+
+    expect($teacher->hub_default_generation)->toBe(2);
+    expect($teacher->hub_default_creating)->toBe('all_full');
+    expect($teacher->hub_default_query_level)->toBe('sql');
+});
+
+test('save rejects an invalid hub default creating value', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    Livewire::actingAs($teacher)
+        ->test(UserHubSettings::class)
+        ->set('hubDefaultCreating', 'not-a-real-option')
+        ->call('save')
+        ->assertHasErrors(['hubDefaultCreating' => 'in']);
+});
+
+test('save rejects an invalid query level value', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    Livewire::actingAs($teacher)
+        ->test(UserHubSettings::class)
+        ->set('hubDefaultQueryLevel', 'not-a-real-level')
+        ->call('save')
+        ->assertHasErrors(['hubDefaultQueryLevel' => 'in']);
+});

--- a/tests/Feature/Livewire/UserPasswordResetTest.php
+++ b/tests/Feature/Livewire/UserPasswordResetTest.php
@@ -1,0 +1,32 @@
+<?php
+
+use App\Livewire\UserPasswordReset;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+use Livewire\Livewire;
+
+test('mount exposes the username and read-only state with no password yet', function () {
+    $target = User::factory()->create(['username' => 'targetuser']);
+
+    Livewire::test(UserPasswordReset::class, ['username' => $target->username])
+        ->assertSet('username', 'targetuser')
+        ->assertSet('newPassword', null)
+        ->assertSet('isReadOnly', false);
+});
+
+test('getNewPassword generates and persists a fresh 6 character password', function () {
+    $target = User::factory()->create(['username' => 'targetuser']);
+    $originalHash = $target->password;
+
+    $component = Livewire::test(UserPasswordReset::class, ['username' => $target->username])
+        ->call('getNewPassword');
+
+    $newPassword = $component->get('newPassword');
+
+    expect($newPassword)->toBeString();
+    expect(mb_strlen($newPassword))->toBe(6);
+
+    $target->refresh();
+    expect($target->password)->not->toBe($originalHash);
+    expect(Hash::check($newPassword, $target->password))->toBeTrue();
+});

--- a/tests/Feature/Livewire/UserSearchTest.php
+++ b/tests/Feature/Livewire/UserSearchTest.php
@@ -1,0 +1,43 @@
+<?php
+
+use App\Livewire\UserSearch;
+use App\Models\User;
+use Livewire\Livewire;
+
+test('query shorter than two characters hides the dropdown and clears results', function () {
+    Livewire::test(UserSearch::class)
+        ->set('query', 'a')
+        ->assertSet('showDropdown', false)
+        ->assertSet('users', []);
+});
+
+test('matching users by username populate the dropdown', function () {
+    $match = User::factory()->create(['username' => 'johndoe', 'name' => 'Zed Zed']);
+    User::factory()->create(['username' => 'somebodyelse', 'name' => 'Nobody Here']);
+
+    Livewire::test(UserSearch::class)
+        ->set('query', 'john')
+        ->assertSet('showDropdown', true)
+        ->assertSee($match->username);
+});
+
+test('matching users by forename or lastname populate the dropdown', function () {
+    $forename = User::factory()->create(['username' => 'aaa111', 'name' => 'Marple Someone']);
+    $lastname = User::factory()->create(['username' => 'bbb222', 'name' => 'Someone Marple']);
+    User::factory()->create(['username' => 'ccc333', 'name' => 'Totally Unrelated']);
+
+    $component = Livewire::test(UserSearch::class)->set('query', 'Marple');
+
+    $component->assertSee($forename->username)
+        ->assertSee($lastname->username);
+});
+
+test('resetDropdown hides the dropdown', function () {
+    User::factory()->create(['username' => 'findable']);
+
+    Livewire::test(UserSearch::class)
+        ->set('query', 'find')
+        ->assertSet('showDropdown', true)
+        ->call('resetDropdown')
+        ->assertSet('showDropdown', false);
+});

--- a/tests/Feature/Notifications/NewUserTest.php
+++ b/tests/Feature/Notifications/NewUserTest.php
@@ -1,0 +1,63 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\NewUser;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+// tests/Pest.php only wires RefreshDatabase into a fixed set of directories
+// (not Feature/Notifications), so opt this file in locally to keep each test
+// isolated instead of leaking rows into the shared `testing_f` database.
+uses(RefreshDatabase::class);
+
+test('it is sent via mail only', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $notification = new NewUser($teacher, 'Please let me in.');
+
+    expect($notification->via($teacher))->toBe(['mail']);
+});
+
+test('the mail message links to the activation action and includes the message', function () {
+    $teacher = User::factory()->teacher()->create([
+        'name' => 'Ada Lovelace',
+        'email' => 'ada@example.test',
+        'username' => 'adalovelace',
+    ]);
+
+    $notification = new NewUser($teacher, 'Custom message <b>with html</b>');
+
+    $mail = $notification->toMail($teacher);
+
+    expect($mail->subject)->toBe('New Teacher');
+    expect($mail->actionUrl)->toBe(config('app.url_admin').'/adalovelace/activate');
+    expect($mail->actionText)->toBe('Activate Teacher');
+
+    $rendered = implode(' ', $mail->introLines);
+    expect($rendered)->toContain('Ada Lovelace');
+    expect($rendered)->toContain('ada@example.test');
+
+    $messageLine = implode(' ', $mail->outroLines);
+    expect($messageLine)->toContain('Custom message &lt;b&gt;with html&lt;/b&gt;');
+});
+
+test('toArray returns an empty array', function () {
+    $teacher = User::factory()->teacher()->create();
+
+    $notification = new NewUser($teacher, 'hi');
+
+    expect($notification->toArray($teacher))->toBe([]);
+});
+
+test('it can be dispatched to a notifiable via notify()', function () {
+    Notification::fake();
+
+    $admin = User::factory()->admin()->create();
+    $teacher = User::factory()->teacher()->create();
+
+    $admin->notify(new NewUser($teacher, 'hello'));
+
+    Notification::assertSentTo($admin, NewUser::class, function ($notification) use ($teacher) {
+        return $notification->user->is($teacher) && $notification->message === 'hello';
+    });
+});

--- a/tests/Feature/Notifications/UserActivatedTest.php
+++ b/tests/Feature/Notifications/UserActivatedTest.php
@@ -1,0 +1,69 @@
+<?php
+
+use App\Models\User;
+use App\Notifications\UserActivated;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+
+// tests/Pest.php only wires RefreshDatabase into a fixed set of directories
+// (not Feature/Notifications), so opt this file in locally to keep each test
+// isolated instead of leaking rows into the shared `testing_f` database.
+uses(RefreshDatabase::class);
+
+test('it is sent via mail only', function () {
+    $notification = new UserActivated('http://example.localhost/');
+
+    expect($notification->via(User::factory()->make()))->toBe(['mail']);
+});
+
+test('the mail message tells the user they were activated and links to the app', function () {
+    $notification = new UserActivated('http://myhub.localhost/');
+
+    $mail = $notification->toMail(User::factory()->make());
+
+    expect($mail->actionUrl)->toBe('http://myhub.localhost/');
+    expect($mail->actionText)->toBe(__('Visit').' '.config('app.name'));
+
+    $rendered = implode(' ', $mail->introLines);
+    expect($rendered)->toContain(__('Your account have been activated.'));
+});
+
+test('toArray returns an empty array', function () {
+    $notification = new UserActivated('http://example.localhost/');
+
+    expect($notification->toArray(User::factory()->make()))->toBe([]);
+});
+
+test('it is sent to a user when notified directly', function () {
+    Notification::fake();
+
+    $user = User::factory()->create();
+
+    $user->notify(new UserActivated('http://example.localhost/'));
+
+    Notification::assertSentTo($user, UserActivated::class);
+});
+
+test('saving an existing user as active triggers the notification outside a hub', function () {
+    Notification::fake();
+
+    // RequestHub::url(), used inside the User model's "updating" listener,
+    // reads $_SERVER['HTTP_HOST'], which is only populated for real HTTP
+    // requests. Simulate that here since this test saves the model directly.
+    $_SERVER['HTTP_HOST'] = 'admin.localhost';
+
+    $user = User::factory()->inactive()->create();
+
+    $user->is_active = true;
+    $user->save();
+
+    Notification::assertSentTo($user, UserActivated::class);
+});
+
+test('creating an already-active user does not trigger the notification', function () {
+    Notification::fake();
+
+    User::factory()->create(['is_active' => true]);
+
+    Notification::assertNothingSent();
+});

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,0 +1,43 @@
+<?php
+
+use Illuminate\Foundation\Testing\DatabaseMigrations;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\ProvisionsHubs;
+use Tests\TestCase;
+
+/*
+|--------------------------------------------------------------------------
+| Test Case bindings
+|--------------------------------------------------------------------------
+|
+| InstaHub is a multi-tenant app: each "hub" lives in its own database that is
+| provisioned at runtime via CREATE DATABASE / GRANT. Those DDL statements
+| implicitly commit, which is incompatible with the transaction-based
+| RefreshDatabase trait. We therefore split the suite:
+|
+|  - Most tests run against the primary DB only and use the fast,
+|    transactional RefreshDatabase.
+|  - Tests under Feature/Hub provision real tenant databases and instead use
+|    DatabaseMigrations (migrate:fresh per test, no wrapping transaction) plus
+|    the ProvisionsHubs helpers. Tenant DBs are dropped in TestCase::tearDown.
+|
+*/
+
+uses(TestCase::class)->in('Feature', 'Unit');
+
+uses(RefreshDatabase::class)
+    ->in('Feature/Auth', 'Feature/Admin', 'Feature/Controllers', 'Feature/Livewire', 'Unit');
+
+uses(DatabaseMigrations::class, ProvisionsHubs::class)->in('Feature/Hub');
+
+/*
+|--------------------------------------------------------------------------
+| Expectations & helpers
+|--------------------------------------------------------------------------
+*/
+
+expect()->extend('toBeActiveUser', function () {
+    expect($this->value->is_active)->toBeTrue();
+
+    return $this;
+});

--- a/tests/ProvisionsHubs.php
+++ b/tests/ProvisionsHubs.php
@@ -1,0 +1,149 @@
+<?php
+
+namespace Tests;
+
+use App\Facades\RequestHub;
+use App\Models\Hub;
+use App\Models\User;
+use Closure;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Test helpers for InstaHub's multi-tenant ("hub") architecture.
+ *
+ * Every hub gets its own MySQL/MariaDB database (`<DB_DATABASE>_<hub_id>`)
+ * with a dedicated DB user, exactly mirroring what HubController@store does in
+ * production. These helpers let feature/unit tests create fully provisioned
+ * hubs and run assertions "inside" a hub (i.e. with the tenant DB active and
+ * RequestHub::isHub() returning true).
+ *
+ * Requires a MySQL/MariaDB server the test user can CREATE/DROP DATABASE and
+ * CREATE USER / GRANT on (root in CI). Tenant databases are torn down in
+ * Tests\TestCase::tearDown().
+ */
+trait ProvisionsHubs
+{
+    /**
+     * Create an active teacher in the primary database.
+     */
+    protected function createTeacher(array $attributes = []): User
+    {
+        RequestHub::setDefaultDB();
+
+        $user = User::create(array_merge([
+            'username' => 'teacher_'.uniqid(),
+            'name' => 'Teacher',
+            'email' => 'teacher_'.uniqid().'@instahub.test',
+            'password' => bcrypt('password'),
+            'role' => 'teacher',
+            'is_active' => true,
+            'hub_default_generation' => 1,
+            'hub_default_creating' => 'all_empty',
+            'hub_default_query_level' => 1,
+        ], $attributes));
+
+        // email_verified_at is guarded, so it is dropped by mass assignment
+        // above; set it explicitly so the teacher passes the `verified`
+        // middleware on the admin domain.
+        if (! array_key_exists('email_verified_at', $attributes)) {
+            $user->forceFill(['email_verified_at' => now()])->save();
+        }
+
+        return $user;
+    }
+
+    /**
+     * Provision a fully working hub, mirroring HubController@store.
+     *
+     * @param  string  $creating  one of: users | all_empty | all_full
+     */
+    protected function createHub(?User $teacher = null, array $attributes = [], string $creating = 'all_empty'): Hub
+    {
+        RequestHub::setDefaultDB();
+
+        $teacher ??= $this->createTeacher();
+
+        $hub = Hub::create(array_merge([
+            'name' => 'hub'.strtolower(str_replace('.', '', uniqid())),
+            'teacher_id' => $teacher->id,
+            'password' => 'secret'.rand(1000, 9999),
+            'generation' => $teacher->hub_default_generation,
+            'query_level' => $teacher->hub_default_query_level,
+        ], $attributes));
+
+        $dbName = env('DB_DATABASE', 'testing').'_'.$hub->id;
+
+        DB::statement("CREATE DATABASE IF NOT EXISTS `{$dbName}`");
+        DB::statement("GRANT ALL ON `{$dbName}`.* TO '{$dbName}'@'localhost' IDENTIFIED BY '{$hub->password}'");
+
+        RequestHub::useHubDB($hub->id, function () use ($hub, $creating) {
+            if ($creating === 'users') {
+                $hub->changeTables(['users'], 'fill');
+            } elseif ($creating === 'all_full') {
+                $hub->changeTables(['users', 'photos', 'tags', 'likes', 'follows', 'comments', 'analytics', 'ads'], 'fill');
+            } else { // all_empty
+                $hub->changeTables(['users', 'photos', 'tags', 'likes', 'follows', 'comments', 'analytics', 'ads'], 'create');
+            }
+        });
+
+        RequestHub::setDefaultDB();
+
+        return $hub;
+    }
+
+    /**
+     * Run a callback with the given hub's tenant database active and
+     * RequestHub reporting hub context (isHub() === true).
+     */
+    protected function withinHub(Hub $hub, Closure $callback)
+    {
+        $previousHost = $_SERVER['HTTP_HOST'] ?? null;
+        $_SERVER['HTTP_HOST'] = $hub->name.'.'.$this->hubBaseDomain();
+
+        app()->forgetInstance('requestHub');
+        RequestHub::clearResolvedInstances();
+        app('requestHub'); // HubHelper constructor detects the hub subdomain
+
+        try {
+            return $callback($hub);
+        } finally {
+            RequestHub::setDefaultDB();
+            if ($previousHost === null) {
+                unset($_SERVER['HTTP_HOST']);
+            } else {
+                $_SERVER['HTTP_HOST'] = $previousHost;
+            }
+            app()->forgetInstance('requestHub');
+            RequestHub::clearResolvedInstances();
+        }
+    }
+
+    /**
+     * Prepare the environment so a subsequent HTTP request ($this->get(...))
+     * to an absolute hub URL is handled in hub context.
+     *
+     * Usage: $this->onHub($hub)->get('http://'.$hub->name.'.localhost/');
+     */
+    protected function onHub(Hub $hub): static
+    {
+        $_SERVER['HTTP_HOST'] = $hub->name.'.'.$this->hubBaseDomain();
+        app()->forgetInstance('requestHub');
+        RequestHub::clearResolvedInstances();
+
+        return $this->withServerVariables(['HTTP_HOST' => $_SERVER['HTTP_HOST']]);
+    }
+
+    /**
+     * Absolute base URL for a hub subdomain, e.g. "http://foo.localhost".
+     */
+    protected function hubUrl(Hub $hub, string $path = '/'): string
+    {
+        return 'http://'.$hub->name.'.'.$this->hubBaseDomain().'/'.ltrim($path, '/');
+    }
+
+    protected function hubBaseDomain(): string
+    {
+        // domain_hub is like "{subdomain}.localhost" -> "localhost"
+        return trim(str_replace('{subdomain}', '', config('app.domain_hub')), '.');
+    }
+}

--- a/tests/README.md
+++ b/tests/README.md
@@ -1,0 +1,94 @@
+# InstaHub Test Suite (Pest)
+
+InstaHub is a **multi-tenant Laravel + Livewire app**. Each "hub" (subdomain)
+lives in its **own MySQL/MariaDB database** (`<DB_DATABASE>_<hub_id>`) with its
+own DB user. The active database is switched at runtime by
+`App\Facades\RequestHub` (backed by `App\Helpers\HubHelper`) based on
+`$_SERVER['HTTP_HOST']`.
+
+Tests run against a real **MariaDB/MySQL** server (never SQLite): the code uses
+`SHOW TABLES`, `FIELD()`, `CREATE/DROP DATABASE`, `GRANT ... IDENTIFIED BY`, and
+the `mysql`/`information_schema` catalogs.
+
+## Directory layout & database lifecycle
+
+| Directory                | Trait applied (via `tests/Pest.php`)            | Use for |
+|--------------------------|-------------------------------------------------|---------|
+| `tests/Unit`             | `RefreshDatabase` (transactional)               | Pure model/rule/helper logic. |
+| `tests/Feature/Auth`     | `RefreshDatabase`                               | Login, register, password reset, verification, middleware. |
+| `tests/Feature/Admin`    | `RefreshDatabase`                               | Controllers/routes on `admin.localhost` (primary DB only). |
+| `tests/Feature/Controllers` | `RefreshDatabase`                            | Controllers on the primary DB / main domain. |
+| `tests/Feature/Livewire` | `RefreshDatabase`                               | Livewire components that only touch the primary DB. |
+| `tests/Feature/Hub`      | `DatabaseMigrations` + `ProvisionsHubs`         | **Anything that provisions or uses a tenant DB.** |
+
+**Why the split:** provisioning a hub runs `CREATE DATABASE` / `GRANT`, which
+implicitly commits and breaks the transactional `RefreshDatabase`. So tenant
+tests use `DatabaseMigrations` (no wrapping transaction). Tenant databases are
+dropped automatically after every test in `Tests\TestCase::tearDown()`.
+
+> Put a test in `Feature/Hub` **iff** it calls `createHub()` / `withinHub()` /
+> `onHub()` or otherwise switches to a tenant DB. Everything else goes in the
+> transactional directories (much faster).
+
+## Golden rules
+
+1. **Use factories, not `User::create([...])`.** `email_verified_at`, `role`
+   nuances etc. are guarded; `User::create()` silently drops guarded fields and
+   your user ends up unverified → redirected to `/email/verify`. Factories
+   bypass mass-assignment protection.
+   - `User::factory()->teacher()->create()` / `->admin()` / `->dba()` /
+     `->user()` / `->unverified()` / `->inactive()`.
+   - Tenant model factories: `Photo`, `Comment`, `Like`, `Tag`, `Ad`,
+     `Analytic`. `Hub::factory()` inserts a row **without** provisioning a tenant
+     DB (fine for admin listing tests only).
+2. **Views need no Vite build** — `TestCase::setUp()` calls `withoutVite()`
+   globally. Just `->assertOk()`.
+3. **Domains matter.** Routes are grouped by domain:
+   - main site: `http://localhost/`
+   - admin area: `http://admin.localhost/`
+   - a hub: `http://<hubname>.localhost/`
+   Always request **absolute URLs** so the correct route group matches.
+
+## Hub helpers (available in `tests/Feature/Hub`, via `ProvisionsHubs`)
+
+```php
+// Fully provision a hub (real tenant DB + tables), mirroring HubController@store.
+$hub = $this->createHub();                       // empty tables (all_empty)
+$hub = $this->createHub(creating: 'users');      // seed users generation
+$hub = $this->createHub(creating: 'all_full');   // seed all tables
+$teacher = $this->createTeacher();               // active teacher in primary DB
+$hub = $this->createHub($teacher);
+
+// Run code with the tenant DB active and RequestHub::isHub() === true.
+$user = $this->withinHub($hub, function () {
+    return \App\Models\User::factory()->create();   // created in the tenant DB
+});
+
+// Make an authenticated HTTP request in hub context:
+$this->onHub($hub)
+    ->actingAs($user)                                 // $user fetched via withinHub()
+    ->get($this->hubUrl($hub, '/'))                   // http://<hub>.localhost/
+    ->assertOk();
+```
+
+Notes:
+- Tenant models (`Photo`, `Comment`, `Like`, `Tag`, `Ad`, `Analytic`) only exist
+  inside a hub — create/query them inside `withinHub()` or during an `onHub()`
+  request.
+- `RequestHub` is a facade; mock hub context in *unit* tests with
+  `RequestHub::shouldReceive('isHub')->andReturn(true)` etc.
+
+## Running
+
+```bash
+php vendor/bin/pest                 # whole suite
+php vendor/bin/pest tests/Unit      # a directory
+php vendor/bin/pest --filter=foo
+```
+
+Requires a reachable MySQL/MariaDB (`DB_HOST`/`DB_PORT`/`DB_USERNAME`/
+`DB_PASSWORD`/`DB_DATABASE` — see `phpunit.xml`) whose user may
+`CREATE/DROP DATABASE`, `CREATE USER` and `GRANT` (root in CI). The DB server
+must sit on the **same host** as the app (so `127.0.0.1` resolves to `localhost`
+and the hubs' `@'localhost'` grants match) — CI installs MariaDB directly on the
+runner rather than using a service container.

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,0 +1,72 @@
+<?php
+
+namespace Tests;
+
+use Illuminate\Foundation\Testing\TestCase as BaseTestCase;
+use Illuminate\Support\Facades\DB;
+
+abstract class TestCase extends BaseTestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // Views reference compiled Vite assets via @vite; there is no build in
+        // the test/CI environment, so replace Vite with a no-op to avoid
+        // "Vite manifest not found" errors while rendering views.
+        $this->withoutVite();
+    }
+
+
+    /**
+     * Clean up any tenant ("hub") databases created during a test.
+     *
+     * InstaHub provisions one MySQL/MariaDB database per hub
+     * (`<DB_DATABASE>_<hub_id>`). Those live outside the transactional
+     * RefreshDatabase lifecycle (CREATE/DROP DATABASE implicitly commits),
+     * so we drop them explicitly after every test to keep the server clean.
+     */
+    protected function tearDown(): void
+    {
+        $this->dropTenantDatabases();
+
+        // Reset any hub-subdomain host set by the ProvisionsHubs helpers so it
+        // cannot leak into the next test.
+        unset($_SERVER['HTTP_HOST']);
+        if ($this->app !== null) {
+            $this->app->forgetInstance('requestHub');
+        }
+
+        parent::tearDown();
+    }
+
+    protected function dropTenantDatabases(): void
+    {
+        // Make sure we are talking to the primary connection.
+        config(['database.default' => 'mysql']);
+
+        $prefix = env('DB_DATABASE', 'testing').'_';
+
+        try {
+            $databases = DB::connection('mysql')->select(
+                'SELECT SCHEMA_NAME AS name FROM information_schema.schemata WHERE SCHEMA_NAME LIKE ?',
+                [str_replace('_', '\_', $prefix).'%']
+            );
+        } catch (\Throwable $e) {
+            // Connection might not be available (e.g. pure unit test) – nothing to clean.
+            return;
+        }
+
+        foreach ($databases as $database) {
+            $name = $database->name;
+
+            DB::connection('mysql')->statement("DROP DATABASE IF EXISTS `{$name}`");
+            DB::connection('mysql')->statement("DROP USER IF EXISTS '{$name}'@'localhost'");
+            DB::connection('mysql')->statement("DROP USER IF EXISTS '{$name}'@'%'");
+        }
+
+        if (! empty($databases)) {
+            DB::connection('mysql')->statement('FLUSH PRIVILEGES');
+        }
+    }
+}

--- a/tests/Unit/Models/UserTest.php
+++ b/tests/Unit/Models/UserTest.php
@@ -1,0 +1,227 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Models\User;
+use Illuminate\Support\Facades\Hash;
+
+/*
+|--------------------------------------------------------------------------
+| App\Models\User (primary-DB-only behaviour)
+|--------------------------------------------------------------------------
+|
+| Covers permission matrix, token bookkeeping, age/profile helpers,
+| relationships that only need the primary database (hubs()), hidden
+| attributes, cryptpw() and the creating() boot hook that stamps
+| tokens_max outside of hub context.
+|
+| Anything that needs the tenant-only `follows`/`photos` tables (isfollowing,
+| following(), followers(), photos(), getSuggested()) lives in
+| tests/Feature/Hub/Models/UserHubTest.php instead.
+*/
+
+describe('allowed()', function () {
+    it('always allows the "user" role regardless of the actual role', function ($role) {
+        $user = User::factory()->make(['role' => $role]);
+
+        expect($user->allowed('user'))->toBeTrue();
+    })->with(['user', 'dba', 'teacher', 'admin']);
+
+    it('allows "dba" for dba, teacher and admin roles but not for user', function () {
+        expect(User::factory()->make(['role' => 'dba'])->allowed('dba'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'teacher'])->allowed('dba'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'admin'])->allowed('dba'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'user'])->allowed('dba'))->toBeFalse();
+    });
+
+    it('allows "teacher" for teacher and admin roles but not for user or dba', function () {
+        expect(User::factory()->make(['role' => 'teacher'])->allowed('teacher'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'admin'])->allowed('teacher'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'user'])->allowed('teacher'))->toBeFalse();
+        expect(User::factory()->make(['role' => 'dba'])->allowed('teacher'))->toBeFalse();
+    });
+
+    it('allows "admin" only for the admin role', function () {
+        expect(User::factory()->make(['role' => 'admin'])->allowed('admin'))->toBeTrue();
+        expect(User::factory()->make(['role' => 'teacher'])->allowed('admin'))->toBeFalse();
+        expect(User::factory()->make(['role' => 'dba'])->allowed('admin'))->toBeFalse();
+        expect(User::factory()->make(['role' => 'user'])->allowed('admin'))->toBeFalse();
+    });
+
+    it('rejects unknown role checks entirely', function () {
+        expect(User::factory()->make(['role' => 'admin'])->allowed('superadmin'))->toBeFalse();
+    });
+});
+
+describe('hasTokens()', function () {
+    it('is true when remaining tokens are >= the requested amount', function () {
+        $user = User::factory()->make(['tokens_max' => 100, 'tokens_used' => 90]);
+
+        expect($user->hasTokens(10))->toBeTrue();
+        expect($user->hasTokens())->toBeTrue(); // default amount = 1
+    });
+
+    it('is false once the requested amount exceeds the remaining budget', function () {
+        $user = User::factory()->make(['tokens_max' => 100, 'tokens_used' => 90]);
+
+        expect($user->hasTokens(11))->toBeFalse();
+    });
+
+    it('is false when tokens are fully exhausted', function () {
+        $user = User::factory()->make(['tokens_max' => 10, 'tokens_used' => 10]);
+
+        expect($user->hasTokens())->toBeFalse();
+    });
+});
+
+describe('age()', function () {
+    it('returns "unknown" when there is no birthday', function () {
+        $user = User::factory()->make(['birthday' => null]);
+
+        expect($user->age())->toBe('unknown');
+    });
+
+    it('computes the age in full years from the birthday', function () {
+        $user = User::factory()->make(['birthday' => now()->subYears(25)->subDays(1)]);
+
+        expect($user->age())->toBe(25);
+    });
+
+    it('returns "unknown" when the computed interval exceeds 2000 years (sentinel birthday)', function () {
+        // Historically used as an "unset"/sentinel birthday; the interval in
+        // years vastly exceeds 2000, which age() treats as "unknown".
+        $user = User::factory()->make(['birthday' => '9999-12-31']);
+
+        expect($user->age())->toBe('unknown');
+    });
+});
+
+describe('getProfileDescriptionAttribute()', function () {
+    it('is empty when there is no city, country, gender or known age', function () {
+        $user = User::factory()->make([
+            'city' => null, 'country' => null, 'gender' => null, 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('');
+    });
+
+    it('renders city+country together', function () {
+        $user = User::factory()->make([
+            'city' => 'Berlin', 'country' => 'Germany', 'gender' => null, 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('is from Berlin (Germany)');
+    });
+
+    it('renders only the country when there is no city', function () {
+        $user = User::factory()->make([
+            'city' => null, 'country' => 'Germany', 'gender' => null, 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('is from Germany');
+    });
+
+    it('ignores a city without a country', function () {
+        $user = User::factory()->make([
+            'city' => 'Berlin', 'country' => null, 'gender' => null, 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('');
+    });
+
+    it('renders only the gender when nothing else is known', function () {
+        $user = User::factory()->make([
+            'city' => null, 'country' => null, 'gender' => 'female', 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('is female');
+    });
+
+    it('renders only the age when nothing else is known', function () {
+        $user = User::factory()->make([
+            'city' => null, 'country' => null, 'gender' => null, 'birthday' => now()->subYears(30),
+        ]);
+
+        expect($user->profile_description)->toBe('is 30 years old');
+    });
+
+    it('joins exactly two parts with "and"', function () {
+        $user = User::factory()->make([
+            'city' => null, 'country' => 'Germany', 'gender' => 'male', 'birthday' => null,
+        ]);
+
+        expect($user->profile_description)->toBe('is from Germany and is male.');
+    });
+
+    it('joins three parts with commas and a trailing "and"', function () {
+        $user = User::factory()->make([
+            'city' => 'Berlin', 'country' => 'Germany', 'gender' => 'male', 'birthday' => now()->subYears(20),
+        ]);
+
+        expect($user->profile_description)->toBe('is from Berlin (Germany), is male and is 20 years old.');
+    });
+});
+
+describe('hidden attributes', function () {
+    it('hides password and remember_token from array/json representations', function () {
+        $user = User::factory()->create();
+
+        $array = $user->toArray();
+
+        expect($array)->not->toHaveKey('password');
+        expect($array)->not->toHaveKey('remember_token');
+    });
+});
+
+describe('cryptpw()', function () {
+    it('bcrypt-hashes a plain text password and persists it', function () {
+        $user = User::factory()->create();
+        $user->forceFill(['password' => 'plaintext-password'])->save();
+
+        $user->cryptpw();
+
+        expect($user->password)->not->toBe('plaintext-password');
+        expect(str_starts_with($user->password, '$2y$'))->toBeTrue();
+        expect($user->fresh()->password)->toBe($user->password);
+    });
+
+    it('leaves a password alone once it already looks like a $2y$10$ bcrypt hash', function () {
+        $user = User::factory()->create();
+        $fakeHash = '$2y$10$'.str_repeat('a', 53);
+        $user->forceFill(['password' => $fakeHash])->save();
+
+        $user->cryptpw();
+
+        expect($user->password)->toBe($fakeHash);
+    });
+});
+
+describe('hubs() relationship', function () {
+    it('returns the hubs created by this teacher', function () {
+        $teacher = User::factory()->teacher()->create();
+        $otherTeacher = User::factory()->teacher()->create();
+
+        $ownHub = \App\Models\Hub::factory()->create(['teacher_id' => $teacher->id]);
+        \App\Models\Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+        $hubs = $teacher->hubs;
+
+        expect($hubs)->toHaveCount(1);
+        expect($hubs->first()->id)->toBe($ownHub->id);
+    });
+});
+
+describe('boot() creating hook', function () {
+    it('sets tokens_max from config outside of hub context', function () {
+        $user = User::factory()->create();
+
+        expect($user->tokens_max)->toBe(config('openai.max_tokens'));
+    });
+
+    it('does not override an explicitly provided tokens_max while inside a hub', function () {
+        RequestHub::shouldReceive('isHub')->andReturn(true);
+
+        $user = User::factory()->create(['tokens_max' => 42]);
+
+        expect($user->tokens_max)->toBe(42);
+    });
+});

--- a/tests/Unit/Policies/HubPolicyTest.php
+++ b/tests/Unit/Policies/HubPolicyTest.php
@@ -1,0 +1,100 @@
+<?php
+
+use App\Models\Hub;
+use App\Models\User;
+use App\Policies\HubPolicy;
+
+beforeEach(function () {
+    $this->policy = new HubPolicy;
+});
+
+describe('viewAny', function () {
+    it('allows admins and teachers', function () {
+        expect($this->policy->viewAny(User::factory()->admin()->make()))->toBeTrue();
+        expect($this->policy->viewAny(User::factory()->teacher()->make()))->toBeTrue();
+    });
+
+    it('denies plain users and dbas', function () {
+        expect($this->policy->viewAny(User::factory()->user()->make()))->toBeFalse();
+        expect($this->policy->viewAny(User::factory()->dba()->make()))->toBeFalse();
+    });
+});
+
+describe('view', function () {
+    it('allows an admin to view any hub', function () {
+        $admin = User::factory()->admin()->create();
+        $hub = Hub::factory()->create();
+
+        expect($this->policy->view($admin, $hub))->toBeTrue();
+    });
+
+    it('allows the owning teacher to view their hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $teacher->id]);
+
+        expect($this->policy->view($teacher, $hub))->toBeTrue();
+    });
+
+    it('denies a different teacher from viewing the hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $otherTeacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+        expect($this->policy->view($teacher, $hub))->toBeFalse();
+    });
+});
+
+describe('create', function () {
+    it('allows anyone, including guests, to create a hub', function () {
+        expect($this->policy->create(null))->toBeTrue();
+        expect($this->policy->create(User::factory()->user()->make()))->toBeTrue();
+    });
+});
+
+describe('update', function () {
+    it('allows an admin to update any hub', function () {
+        $admin = User::factory()->admin()->create();
+        $hub = Hub::factory()->create();
+
+        expect($this->policy->update($admin, $hub))->toBeTrue();
+    });
+
+    it('allows the owning teacher to update their hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $teacher->id]);
+
+        expect($this->policy->update($teacher, $hub))->toBeTrue();
+    });
+
+    it('denies a different teacher from updating the hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $otherTeacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+        expect($this->policy->update($teacher, $hub))->toBeFalse();
+    });
+});
+
+describe('delete', function () {
+    it('allows an admin to delete any hub', function () {
+        $admin = User::factory()->admin()->create();
+        $hub = Hub::factory()->create();
+
+        expect($this->policy->delete($admin, $hub))->toBeTrue();
+    });
+
+    it('allows the owning teacher to delete their hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $teacher->id]);
+
+        expect($this->policy->delete($teacher, $hub))->toBeTrue();
+    });
+
+    it('denies a different teacher from deleting the hub', function () {
+        $teacher = User::factory()->teacher()->create();
+        $otherTeacher = User::factory()->teacher()->create();
+        $hub = Hub::factory()->create(['teacher_id' => $otherTeacher->id]);
+
+        expect($this->policy->delete($teacher, $hub))->toBeFalse();
+    });
+});

--- a/tests/Unit/Policies/UserPolicyTest.php
+++ b/tests/Unit/Policies/UserPolicyTest.php
@@ -1,0 +1,159 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Models\User;
+use App\Policies\UserPolicy;
+
+beforeEach(function () {
+    $this->policy = new UserPolicy;
+});
+
+function mockOutsideHubForUserPolicyTest(): void
+{
+    RequestHub::shouldReceive('isHub')->andReturn(false);
+}
+
+function mockInsideHubForUserPolicyTest(): void
+{
+    RequestHub::shouldReceive('isHub')->andReturn(true);
+}
+
+describe('viewAny', function () {
+    it('allows anyone inside a hub', function () {
+        mockInsideHubForUserPolicyTest();
+
+        expect($this->policy->viewAny(User::factory()->user()->make()))->toBeTrue();
+    });
+
+    it('outside a hub, only admins may view any user', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        expect($this->policy->viewAny(User::factory()->admin()->make()))->toBeTrue();
+        expect($this->policy->viewAny(User::factory()->teacher()->make()))->toBeFalse();
+        expect($this->policy->viewAny(User::factory()->user()->make()))->toBeFalse();
+    });
+});
+
+describe('view', function () {
+    it('allows anyone inside a hub to view any user', function () {
+        mockInsideHubForUserPolicyTest();
+
+        $user = User::factory()->user()->create();
+        $other = User::factory()->user()->create();
+
+        expect($this->policy->view($user, $other))->toBeTrue();
+    });
+
+    it('outside a hub, allows admins or the user themself', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->user()->create();
+        $otherUser = User::factory()->user()->create();
+
+        expect($this->policy->view($admin, $user))->toBeTrue();
+        expect($this->policy->view($user, $user))->toBeTrue();
+        expect($this->policy->view($user, $otherUser))->toBeFalse();
+    });
+});
+
+describe('create', function () {
+    it('inside a hub, requires at least dba', function () {
+        mockInsideHubForUserPolicyTest();
+
+        expect($this->policy->create(User::factory()->dba()->make()))->toBeTrue();
+        expect($this->policy->create(User::factory()->teacher()->make()))->toBeTrue();
+        expect($this->policy->create(User::factory()->admin()->make()))->toBeTrue();
+        expect($this->policy->create(User::factory()->user()->make()))->toBeFalse();
+    });
+
+    it('outside a hub, requires admin', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        expect($this->policy->create(User::factory()->admin()->make()))->toBeTrue();
+        expect($this->policy->create(User::factory()->dba()->make()))->toBeFalse();
+        expect($this->policy->create(User::factory()->teacher()->make()))->toBeFalse();
+    });
+});
+
+describe('update', function () {
+    it('inside a hub, allows dba or the user themself', function () {
+        mockInsideHubForUserPolicyTest();
+
+        $dba = User::factory()->dba()->create();
+        $user = User::factory()->user()->create();
+        $otherUser = User::factory()->user()->create();
+
+        expect($this->policy->update($dba, $user))->toBeTrue();
+        expect($this->policy->update($user, $user))->toBeTrue();
+        expect($this->policy->update($user, $otherUser))->toBeFalse();
+    });
+
+    it('outside a hub, allows admin or the user themself', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->user()->create();
+        $otherUser = User::factory()->user()->create();
+
+        expect($this->policy->update($admin, $user))->toBeTrue();
+        expect($this->policy->update($user, $user))->toBeTrue();
+        expect($this->policy->update($user, $otherUser))->toBeFalse();
+    });
+});
+
+describe('delete', function () {
+    it('inside a hub, requires dba', function () {
+        mockInsideHubForUserPolicyTest();
+
+        expect($this->policy->delete(User::factory()->dba()->make(), User::factory()->user()->make()))->toBeTrue();
+        expect($this->policy->delete(User::factory()->user()->make(), User::factory()->user()->make()))->toBeFalse();
+    });
+
+    it('outside a hub, requires admin', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        expect($this->policy->delete(User::factory()->admin()->make(), User::factory()->user()->make()))->toBeTrue();
+        expect($this->policy->delete(User::factory()->dba()->make(), User::factory()->user()->make()))->toBeFalse();
+    });
+});
+
+describe('toggleActive', function () {
+    it('inside a hub, requires dba', function () {
+        mockInsideHubForUserPolicyTest();
+
+        expect($this->policy->toggleActive(User::factory()->dba()->make(), User::factory()->user()->make()))->toBeTrue();
+        expect($this->policy->toggleActive(User::factory()->user()->make(), User::factory()->user()->make()))->toBeFalse();
+    });
+
+    it('outside a hub, requires admin', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        expect($this->policy->toggleActive(User::factory()->admin()->make(), User::factory()->user()->make()))->toBeTrue();
+        expect($this->policy->toggleActive(User::factory()->dba()->make(), User::factory()->user()->make()))->toBeFalse();
+    });
+});
+
+describe('changePassword', function () {
+    it('inside a hub, allows dba or the user themself', function () {
+        mockInsideHubForUserPolicyTest();
+
+        $dba = User::factory()->dba()->create();
+        $user = User::factory()->user()->create();
+
+        expect($this->policy->changePassword($dba, $user))->toBeTrue();
+        expect($this->policy->changePassword($user, $user))->toBeTrue();
+        expect($this->policy->changePassword(User::factory()->user()->create(), $user))->toBeFalse();
+    });
+
+    it('outside a hub, allows admin or the user themself', function () {
+        mockOutsideHubForUserPolicyTest();
+
+        $admin = User::factory()->admin()->create();
+        $user = User::factory()->user()->create();
+
+        expect($this->policy->changePassword($admin, $user))->toBeTrue();
+        expect($this->policy->changePassword($user, $user))->toBeTrue();
+        expect($this->policy->changePassword(User::factory()->dba()->create(), $user))->toBeFalse();
+    });
+});

--- a/tests/Unit/Rules/UrlSafeStringTest.php
+++ b/tests/Unit/Rules/UrlSafeStringTest.php
@@ -1,0 +1,97 @@
+<?php
+
+use App\Rules\UrlSafeString;
+use Illuminate\Support\Facades\Validator;
+
+/**
+ * Directly exercise the rule's validate() callback with a captured failure.
+ */
+function urlSafeStringFails(string $value): array
+{
+    $rule = new UrlSafeString;
+    $failures = [];
+
+    $rule->validate('field', $value, function (string $message) use (&$failures) {
+        $failures[] = $message;
+    });
+
+    return $failures;
+}
+
+it('passes plain alphanumeric strings', function () {
+    expect(urlSafeStringFails('my-cool_username123'))->toBeEmpty();
+});
+
+it('passes an empty string (no forbidden chars present)', function () {
+    expect(urlSafeStringFails(''))->toBeEmpty();
+});
+
+it('passes dots and hyphens and underscores', function () {
+    expect(urlSafeStringFails('foo.bar-baz_qux'))->toBeEmpty();
+});
+
+it('fails and reports a single forbidden character', function (string $char) {
+    expect(urlSafeStringFails("abc{$char}def"))->not->toBeEmpty();
+})->with([
+    '/', '?', '#', '[', ']', '@', '!', '$', '&', "'",
+    '(', ')', '*', '+', ',', ';', '=',
+]);
+
+it('fails on a literal space and reports the translated placeholder', function () {
+    $failures = urlSafeStringFails('hello world');
+
+    expect($failures)->not->toBeEmpty()
+        ->and($failures[0])->toContain(__('validation.chars.space'));
+});
+
+it('fails on a tab character and reports the translated placeholder', function () {
+    $failures = urlSafeStringFails("hello\tworld");
+
+    expect($failures)->not->toBeEmpty()
+        ->and($failures[0])->toContain(__('validation.chars.tab'));
+});
+
+it('fails on newlines and carriage returns, both reported as line break', function () {
+    $failuresNewline = urlSafeStringFails("hello\nworld");
+    $failuresCarriage = urlSafeStringFails("hello\rworld");
+
+    expect($failuresNewline[0])->toContain(__('validation.chars.line_break'));
+    expect($failuresCarriage[0])->toContain(__('validation.chars.line_break'));
+});
+
+it('deduplicates repeated forbidden characters in the message', function () {
+    $failures = urlSafeStringFails('a/b/c/d');
+
+    expect($failures)->toHaveCount(1);
+    // Only one occurrence of "/" should show up despite 3 matches.
+    $occurrences = substr_count($failures[0], '/');
+    expect($occurrences)->toBe(1);
+});
+
+it('reports every distinct forbidden character found', function () {
+    $failures = urlSafeStringFails('a b/c?d');
+
+    expect($failures)->toHaveCount(1)
+        ->and($failures[0])->toContain(__('validation.chars.space'))
+        ->and($failures[0])->toContain('/')
+        ->and($failures[0])->toContain('?');
+});
+
+it('integrates with the Laravel validator and fails invalid values', function () {
+    $validator = Validator::make(
+        ['slug' => 'not valid/slug'],
+        ['slug' => [new UrlSafeString]]
+    );
+
+    expect($validator->fails())->toBeTrue();
+    expect($validator->errors()->has('slug'))->toBeTrue();
+});
+
+it('integrates with the Laravel validator and passes valid values', function () {
+    $validator = Validator::make(
+        ['slug' => 'valid-slug_123'],
+        ['slug' => [new UrlSafeString]]
+    );
+
+    expect($validator->fails())->toBeFalse();
+});

--- a/tests/Unit/Support/HubHelperTest.php
+++ b/tests/Unit/Support/HubHelperTest.php
@@ -1,0 +1,116 @@
+<?php
+
+use App\Facades\RequestHub;
+use App\Models\User;
+use Illuminate\Support\Facades\Auth;
+
+/*
+|--------------------------------------------------------------------------
+| Non-hub context behaviour of App\Helpers\HubHelper
+|--------------------------------------------------------------------------
+|
+| No $_SERVER['HTTP_HOST'] is set to a hub subdomain in these tests, so the
+| singleton resolves to "not a hub" (RequestHub::isHub() === false). This
+| exercises the primary-DB-only paths of the helper.
+*/
+
+it('defaults to the primary "mysql" connection and is not a hub', function () {
+    expect(config('database.default'))->toBe('mysql');
+    expect(RequestHub::isHub())->toBeFalse();
+});
+
+it('setDefaultDB always points the default connection back at mysql', function () {
+    config(['database.default' => 'some_other_connection']);
+
+    RequestHub::setDefaultDB();
+
+    expect(config('database.default'))->toBe('mysql');
+});
+
+it('useDefaultDB runs the callback against mysql and restores the previous connection', function () {
+    // Force the singleton to be constructed first: HubHelper's constructor
+    // itself resets database.default to "mysql", so it must run *before* we
+    // simulate being on a non-default connection.
+    RequestHub::isHub();
+    config(['database.default' => 'previous_connection']);
+
+    $seenDuringCallback = null;
+
+    $result = RequestHub::useDefaultDB(function () use (&$seenDuringCallback) {
+        $seenDuringCallback = config('database.default');
+
+        return 'callback-result';
+    });
+
+    expect($seenDuringCallback)->toBe('mysql');
+    expect($result)->toBe('callback-result');
+    expect(config('database.default'))->toBe('previous_connection');
+});
+
+it('useDefaultDB restores the previous connection even if the callback throws', function () {
+    RequestHub::isHub();
+    config(['database.default' => 'previous_connection']);
+
+    expect(fn () => RequestHub::useDefaultDB(function () {
+        throw new RuntimeException('boom');
+    }))->toThrow(RuntimeException::class, 'boom');
+
+    expect(config('database.default'))->toBe('previous_connection');
+});
+
+it('reports null for hub-scoped accessors outside of a hub', function () {
+    expect(RequestHub::isReadOnly())->toBeFalse();
+    expect(RequestHub::id())->toBeNull();
+    expect(RequestHub::name())->toBeNull();
+    expect(RequestHub::teacher())->toBeNull();
+    expect(RequestHub::generation())->toBeNull();
+    expect(RequestHub::query_level())->toBeNull();
+});
+
+it('hasTable reflects the tables that exist on the current (primary) connection', function () {
+    expect(RequestHub::hasTable('users'))->toBeTrue();
+    expect(RequestHub::hasTable('this_table_does_not_exist_xyz'))->toBeFalse();
+});
+
+it('hasTokens delegates to the authenticated user outside of a hub', function () {
+    // User::boot() forces tokens_max to config('openai.max_tokens') on
+    // *creation* whenever we are not in hub context, so set the final
+    // values via an update() (which does not go through that hook) to get
+    // deterministic boundaries.
+    $user = User::factory()->create();
+    $user->update(['tokens_used' => 5, 'tokens_max' => 10]);
+    Auth::login($user);
+
+    expect(RequestHub::hasTokens(5))->toBeTrue();
+    expect(RequestHub::hasTokens(6))->toBeFalse();
+});
+
+it('decrementTokens is a no-op outside of a hub', function () {
+    $user = User::factory()->create(['tokens_used' => 0, 'tokens_max' => 10]);
+    Auth::login($user);
+
+    RequestHub::decrementTokens(3);
+
+    expect($user->fresh()->tokens_used)->toBe(0);
+});
+
+it('url() without a name returns the protocol + current HTTP host', function () {
+    $_SERVER['HTTP_HOST'] = 'example.localhost';
+    unset($_SERVER['HTTPS']);
+
+    expect(RequestHub::url())->toBe('http://example.localhost');
+});
+
+it('url() with a name builds the hub subdomain URL from config', function () {
+    unset($_SERVER['HTTPS']);
+
+    expect(RequestHub::url('myhub'))->toBe('http://myhub.localhost');
+});
+
+it('url() uses https when the request was secure', function () {
+    $_SERVER['HTTPS'] = 'on';
+
+    expect(RequestHub::url('myhub'))->toBe('https://myhub.localhost');
+
+    unset($_SERVER['HTTPS']);
+});

--- a/tests/Unit/Support/UserResourceTest.php
+++ b/tests/Unit/Support/UserResourceTest.php
@@ -1,0 +1,26 @@
+<?php
+
+use App\Http\Resources\User as UserResource;
+use App\Models\User;
+
+it('exposes only username, name and avatar', function () {
+    $user = User::factory()->create([
+        'username' => 'jdoe',
+        'name' => 'Jane Doe',
+        'avatar' => 'avatars/jane.jpg',
+        'email' => 'jane@example.test',
+    ]);
+
+    $data = (new UserResource($user))->toArray(request());
+
+    expect($data)->toBe([
+        'username' => 'jdoe',
+        'name' => 'Jane Doe',
+        'avatar' => 'avatars/jane.jpg',
+    ]);
+
+    // Sensitive / unrelated attributes must not leak through the resource.
+    expect($data)->not->toHaveKey('email')
+        ->and($data)->not->toHaveKey('password')
+        ->and($data)->not->toHaveKey('id');
+});


### PR DESCRIPTION
## Summary

Introduces a full **Pest** test suite (390 passing tests, 923 assertions) and a GitHub Actions CI pipeline for InstaHub, and fixes five bugs the suite surfaced. There were no tests before this branch.

Because InstaHub is **multi-tenant** (each hub lives in its own MySQL/MariaDB database, provisioned at runtime via `CREATE DATABASE` + `GRANT ... IDENTIFIED BY`), the harness runs against a real MariaDB and can provision/enter real tenant databases — mirroring `HubController@store`.

### Testing foundation
- Install **Pest 4** (+ Laravel/Livewire plugins); bump **PHPUnit to ^12.5**; pin composer's platform to PHP 8.3 so the lock installs on the CI runner
- `tests/TestCase` — disables Vite for view rendering, drops per-hub tenant databases after each test
- `tests/ProvisionsHubs` — provisions and enters real tenant hub databases (`createHub()`, `withinHub()`, `onHub()`)
- `tests/Pest.php` — transactional `RefreshDatabase` for primary-DB tests; `DatabaseMigrations` + `ProvisionsHubs` for `Feature/Hub` tenant tests (tenant DDL implicitly commits, so it cannot run inside a wrapping transaction)
- Factories for all models (+ `HasFactory` on tenant models); MySQL/MariaDB env wired into `phpunit.xml`
- Harness contract documented in `tests/README.md`

### Coverage (390 passing)
- **Unit** — models, rules, policies, helpers, API resources
- **Feature/Auth** — login, register, password reset, email verification, `loginWithToken`, middleware (Role/IsHub/Subdomain/SetBrowserLocale)
- **Feature/Admin** + **Feature/Hub/AdminControllers** — hub provisioning & teardown (real tenant DBs), user/admin/static/file controllers
- **Feature/Hub/Controllers** — photo, comment, like, follow, ad flows inside tenant DBs
- **Feature/Hub/Models** + **Support** — tenant models, `PhotoCollection`, API resources, `HubHelper` hub context, `User::getSuggested` (MySQL `FIELD()`)
- **Feature/Livewire** + **Feature/Hub/Livewire** — Livewire components
- **Feature/Notifications** — `NewUser`, `UserActivated`

### CI
- `.github/workflows/tests.yml` runs the suite on push/PR. MariaDB is installed **directly on the runner** (not a service container) so that connections to `127.0.0.1` resolve to `localhost` and the hubs' `@'localhost'` grants match. MySQL 8 is unsuitable because it removed `GRANT ... IDENTIFIED BY`.

### JavaScript testing
Vitest was intentionally **not** added — the app's JS is ~57 lines of glue (bootstrap, axios, highlight.js config, friendly-challenge) with no testable business logic.

## Bugs fixed in this PR (surfaced while writing tests)
1. `HubController@store` — used `=` (assignment) instead of `==` when checking the creator's role, which always ran and clobbered the role / forced `teacher_id`. Now compares.
2. `HubController@store` — the `all_empty` creating mode seeded no admin user, so the controller called `->update()` on `null`. Now creates a `dba` admin when none exists.
3. `RegisterController::validator()` — validated a `birthday_birthDay` field instead of `birthday`, so the date rule never applied. Now validates `birthday`.
4. `CommentController@destroy` — had no authorization; any authenticated hub user could delete any comment. Now only the comment author or the photo owner may delete, and a missing comment 404s.
5. `App\Http\Resources\Hub::toArray()` — called `hasWorkingUser()` / `activated()` / `readonly()` as methods, but they are Eloquent accessors → `BadMethodCallException`. Now reads them as properties.

Each fix has accompanying test coverage.

## Test plan
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)