### PR TITLE
Fix /noad route test to use hub subdomain

### DIFF
--- a/tests/Feature/Admin/StaticControllerTest.php
+++ b/tests/Feature/Admin/StaticControllerTest.php
@@ -9,8 +9,14 @@ test('about page renders', function () {
 });
 
 test('noad page renders', function () {
-    // The /noad fallback link is a hub-relative route, so it only resolves on a hub subdomain.
-    $this->get('http://example.localhost/noad')->assertOk();
+    // /noad is a hub-relative route, so it only resolves on a hub subdomain and runs
+    // through the Subdomain middleware, which reads $_SERVER['HTTP_HOST'] to build the
+    // hub URL. Set the host as the hub helpers do so the request is handled in hub context.
+    $_SERVER['HTTP_HOST'] = 'example.localhost';
+
+    $this->withServerVariables(['HTTP_HOST' => 'example.localhost'])
+        ->get('http://example.localhost/noad')
+        ->assertOk();
 });
 
 test('documentation redirect sends generation 1 to its plain configured url', function () {

--- a/tests/Feature/Admin/StaticControllerTest.php
+++ b/tests/Feature/Admin/StaticControllerTest.php
@@ -9,7 +9,8 @@ test('about page renders', function () {
 });
 
 test('noad page renders', function () {
-    $this->get('http://localhost/noad')->assertOk();
+    // The /noad fallback link is a hub-relative route, so it only resolves on a hub subdomain.
+    $this->get('http://example.localhost/noad')->assertOk();
 });
 
 test('documentation redirect sends generation 1 to its plain configured url', function () {


### PR DESCRIPTION
## Was ist kaputt

Der CI-Lauf auf `main` (Commit `94ff09c`, *„fix upgrade laravel routing priorities"*) schlägt fehl — **nicht** wegen falscher Runtimes. PHP 8.5 und Node 24 sind korrekt: `composer.json` verlangt `php: ^8.5` und `laravel/framework: ^13.0`, und die Node-20-Deprecation ist nur eine Warnung (Actions laufen automatisch auf Node 24).

Der Fehler ist genau ein Test:

```
FAILED Tests\Feature\Admin\StaticControllerTest > noad page renders
Expected response status code [200] but received 404.
```

## Ursache

Der Routing-Refactor hat `/noad` aus einer domain-agnostischen Route in die Hub-Subdomain-Gruppe verschoben (`routes/web.php:105`, Gruppe `config('app.domain_hub')` = `{subdomain}.localhost`). `artisan route:list` bestätigt:

```
GET|HEAD  {subdomain}.localhost/noad ... StaticController@noad
```

Der Test rief aber weiter `http://localhost/noad` auf — die Hauptdomain kennt die Route nicht mehr → 404. Das Route-Placement ist gewollt (der Kommentar dort: „relative ad links like `/noad` resolve on hubs"), also muss der Test die Hub-Subdomain ansteuern.

## Änderung

`tests/Feature/Admin/StaticControllerTest.php`: Der `noad`-Test ruft nun `http://example.localhost/noad` auf, konsistent mit der übrigen Hub-Test-Konvention (`http://<hub>.localhost/`).

## Verifikation

- `artisan route:list --path=noad` bestätigt die Subdomain-Bindung als Ursache.
- Der DB-gestützte Feature-Test läuft in der CI (PHP 8.5 + MariaDB); lokal ist MariaDB hier nicht installierbar.
- `pint` grün.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011sV4dnjwWdqBEDsZn3qRcE)_